### PR TITLE
docs: update the link of spec for CAT enhancements

### DIFF
--- a/federated-catalogue/README.md
+++ b/federated-catalogue/README.md
@@ -10,6 +10,6 @@ The XFSC Federated Catalogue (CAT) manages metadata objects (typically credentia
 
 This enhancement of the CAT modularizes its verification of credentials against trust anchors and generalizes its management of metadata objects beyond the former focus on credentials; thus, it will also be able to function as a Template Repository for the FACIS Digital Contract Service (DCS).
 
-The enhanced specification document can be found here : [PDF](https://github.com/Jessia2597/docs/blob/main/federated-catalogue/src/docs/CAT%20Enhancement/CAT_Enhancement_Specifications%20v1.0.pdf)
+The enhanced specification document can be found here : [PDF](https://github.com/eclipse-xfsc/docs/blob/main/federated-catalogue/src/docs/CAT%20Enhancement/CAT_Enhancement_Specifications%20v1.0.pdf)
 
 The implementation of the federated catalogue can be found here : [`implementation/federated-catalogue`](https://github.com/eclipse-xfsc/federated-catalogue)


### PR DESCRIPTION
The spec link was redirecting to the forked repo in README.md, which is now been updated.