### PR TITLE
[CAT-FR-CO-03] foundation: external trust framework interface

### DIFF
--- a/federated-catalogue/src/docs/architecture/chapters/05_building_block_view.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/05_building_block_view.adoc
@@ -172,6 +172,7 @@ NOTE: Non-RDF schemas (JSON Schema, XML Schema) bypass the Schema Store entirely
 | RDF Detector | Classifies uploaded content as RDF or non-RDF based on a configurable MIME type allowlist and content inspection. For `application/json`, the detector checks for a JSON-LD `@context` key to distinguish JSON-LD (RDF) from plain JSON (non-RDF). Note that `application/schema+json` (JSON Schema) and `application/xml` (XSD) are always classified as non-RDF — even though they are schema formats, they are not RDF and do not enter the RDF verification pipeline.
 | Asset Upload Service | Orchestrates the dual-path upload flow: extracts request data, delegates to `RdfDetector` for classification, then routes to either the verification pipeline (RDF) or direct asset storage (non-RDF).
 | Asset Link Service | Manages bidirectional links between machine-readable (RDF) assets and human-readable representations (e.g., PDF, DOCX). Link metadata is stored directly on the `assets` table via an `asset_type` column and a `linked_asset_id` FK; supplementary `fcmeta:hasHumanReadable` / `fcmeta:hasMachineReadable` RDF triples are written to the graph DB.
+| Validation Result Storage | Persists the outcome of on-demand credential validation. Each `ValidationResult` record is stored in PostgreSQL (`validation_result` table) and projected as `fcmeta:` triples in the graph store (`SYNCED`/`FAILED`). Retrieval is exposed via `GET /assets/{id}/validations` (paginated) and `GET /validations/{id}`. After a graph backend reset, `GraphRebuilder.rebuildValidationResults()` re-projects all records from PostgreSQL.
 | Metadata Store | Database keeping all the required metadata for the modules. The Metadata Store is _owned_ by the _Store_ components. For separation, each component gets its own set of tables with no relation between them.
 | File Store | Storage system for persisting files (e.g., file system or object store/DB). Separate instances exist for schemas/contexts and for non-RDF assets.
 |===
@@ -804,6 +805,67 @@ The asset metadata is stored in the metadata store, using the following data mod
 . The table is audited by Hibernate Envers — all insert, update, and delete operations are tracked in the `assets_aud` shadow table (see <<_audit_history>>).
 . The `created_by` and `modified_by` columns are populated by Spring Data JPA auditing via `SecurityAuditorAware`, which reads the JWT subject from the security context. They are null for unauthenticated operations and for rows that predate CAT-FR-LM-03.
 ****
+
+[[_validation_result_storage]]
+==== Validation Result Storage
+
+Stores the outcome of on-demand asset validation as a `ValidationResult` record in PostgreSQL and projects it into the graph store as `fcmeta:` triples, creating a queryable validation history for each asset without re-running verification.
+
+[mermaid, width=2000]
+....
+classDiagram
+    class ValidationResultStore {
+        <<interface>>
+        +store(record: ValidationResultRecord) Long
+        +getByAssetId(assetId: String, pageable: Pageable) Page~ValidationResult~
+        +getById(id: Long) Optional~ValidationResult~
+    }
+    class ValidationResultGraphWriter {
+        +write(result: ValidationResult, graphStore: GraphStore) void
+    }
+    class ValidationResult {
+        +id: Long
+        +assetIds: String[]
+        +validatorIds: String[]
+        +validatorType: String
+        +conforms: boolean
+        +validatedAt: Instant
+        +report: String
+        +contentHash: String
+        +graphSyncStatus: GraphSyncStatus
+        +createdAt: Instant
+    }
+    ValidationResultStore ..> ValidationResult : produces
+    ValidationResultStore ..> ValidationResultGraphWriter : delegates graph write
+....
+
+.VALIDATION_RESULT table
+[cols="1,2,1,3", options="header"]
+|===
+| Type | Column | Key | Note
+
+| BIGINT | id | PK | Surrogate key, sequence-generated (allocation size 50)
+| TEXT[] | asset_ids | | Asset subject IRI(s) — GIN indexed for efficient `= ANY()` lookups
+| TEXT[] | validator_ids | | Validator IDs (schema IRIs or trust framework IDs) used in this run
+| VARCHAR(64) | validator_type | | `SCHEMA` or `TRUST_FRAMEWORK`
+| BOOLEAN | conforms | | True if validation passed; false if violations were found
+| TIMESTAMPTZ | validated_at | | Timestamp of the validation run (caller-supplied, not DB insertion time)
+| JSONB | report | | Serialised validation report; null for passing validations
+| VARCHAR(64) | content_hash | | SHA-256 hex digest over canonical JSON of core fields — tamper detection
+| VARCHAR(16) | graph_sync_status | | `SYNCED` or `FAILED` — set atomically when the record is first stored
+| TIMESTAMPTZ | created_at | | DB insertion time, populated by Spring Data JPA `@CreatedDate`
+|===
+
+The two REST endpoints for validation result retrieval are:
+
+[cols="2,3", options="header"]
+|===
+| Endpoint | Description
+| `GET /assets/{id}/validations` | Paginated list of `StoredValidationResult` for the asset identified by IRI `{id}`. Returns 200 with an empty list if the asset exists but has no stored validations; 404 if the asset does not exist.
+| `GET /validations/{id}` | Single `StoredValidationResult` by its surrogate database ID. Returns 404 if not found.
+|===
+
+After a graph backend reset, `GraphRebuilder.rebuildValidationResults()` re-projects all validation result records as `fcmeta:` triples from PostgreSQL, restoring graph state without re-running verification. Each record is updated to `SYNCED` on success or `FAILED` if the graph write fails.
 
 ==== Schema Management Store
 

--- a/federated-catalogue/src/docs/architecture/chapters/05_building_block_view.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/05_building_block_view.adoc
@@ -351,6 +351,103 @@ When it returns `UNKNOWN`, the strategy delegates to `JenaAllTriplesExtractor` t
 In `verifyCredential()`, it explicitly calls `ProtectedNamespaceFilter.filterClaims()` after claim extraction and propagates any filter warnings to the result.
 The `VerificationStrategy` interface Javadoc documents the namespace filtering requirement (CAT-FR-GD-09) for all implementations.
 
+[[_trust_framework_bundles_and_role_resolution]]
+===== Trust Framework Bundles and Role Resolution
+
+A trust framework's identity, ontology, and SHACL shapes are packaged together as a **bundle** under `classpath:trustframeworks/<bundle-id>/`.
+The catalogue ships with the `gaia-x-2511` bundle and discovers any additional bundles dropped on the classpath at boot.
+See ADR 10 for the full rationale.
+
+[options="header",cols="1,3"]
+|===
+| File | Purpose
+| `framework.yaml` | Bundle metadata (id, family, namespace, validation type) and explicit role declarations
+| `ontology.ttl` | OWL class hierarchy used to derive each role's subclass closure (optional for non-SHACL bundles)
+| `shapes.ttl` | SHACL shapes loaded into the composite schema graph (optional for non-SHACL bundles)
+|===
+
+`TrustFrameworkBundleLoader` scans `classpath:trustframeworks/*/framework.yaml` at startup and constructs a `TrustFrameworkBundle` (config + ontology + shapes) per directory.
+Bundles that fail to load are logged at WARN and skipped — they do not abort the load of remaining bundles.
+
+`TrustFrameworkRegistryImpl` indexes the loaded bundles and exposes role resolution to the verification pipeline:
+
+[mermaid,width=1600]
+....
+classDiagram
+    class TrustFrameworkRegistry {
+        <<interface>>
+        +resolveRole(typeUri) ResolvedRole
+        +getBundles() Collection~TrustFrameworkBundle~
+        +getBundle(profileId) Optional~TrustFrameworkBundle~
+        +getEffectiveRoles(profileId) Set~String~
+        +isFrameworkEnabled(profileId) boolean
+    }
+    class TrustFrameworkRegistryImpl {
+        -typeIndex : Map~String, ResolvedRole~
+        -bundleIndex : Map~String, TrustFrameworkBundle~
+        -activeProfileIds : Set~String~
+    }
+    class TrustFrameworkBundle {
+        <<record>>
+        +config : FrameworkBundleConfig
+        +ontology : ContentAccessor
+        +shapes : ContentAccessor
+    }
+    class FrameworkBundleConfig {
+        <<record>>
+        +id : String
+        +family : String
+        +namespace : String
+        +validationType : ValidationType
+        +roles : Map~String, RoleConfig~
+    }
+    class RoleConfig {
+        <<record>>
+        +additionalRoots : List~String~
+        +types : List~String~
+    }
+    class ResolvedRole {
+        <<record>>
+        +frameworkProfileId : String
+        +role : String
+        +UNKNOWN$
+    }
+    class TrustFrameworkBundleLoader {
+        +loadFromClasspath() List~TrustFrameworkBundle~
+    }
+    TrustFrameworkRegistry <|.. TrustFrameworkRegistryImpl
+    TrustFrameworkRegistryImpl --> TrustFrameworkBundle : indexes
+    TrustFrameworkBundle --> FrameworkBundleConfig
+    FrameworkBundleConfig --> RoleConfig : roles
+    TrustFrameworkRegistryImpl --> ResolvedRole : returns
+    TrustFrameworkBundleLoader --> TrustFrameworkBundle : produces
+    CredentialVerificationStrategy --> TrustFrameworkRegistry : resolves credential subject roles
+....
+
+**Role indexing (SHACL bundles):** for each role declared in `framework.yaml`, the registry takes the root URI as `namespace + roleName`, then walks the OWL hierarchy in `ontology.ttl` via `rdfs:subClassOf*` and indexes every subclass under that role.
+The `additional_roots` list adds non-subclass URIs (siblings, cross-hierarchy mappings) to the same role.
+Bundles whose `validation_type` is not `shacl` are loaded but deferred (no validation engine wired yet); a WARN is logged and the bundle does not appear in `isFrameworkEnabled()`.
+
+**Resolution at verification time:** `CredentialVerificationStrategy` calls `registry.resolveRole(typeUri)` for each `credentialSubject` type encountered in a credential or VP.
+The result `(frameworkProfileId, role)` drives:
+
+* dispatch to the typed verification result (`Participant` / `ServiceOffering` / `Resource` for the bundled `gaia-x-2511` profile — see `VerificationConstants.ROLE_*`),
+* the typed-endpoint expected-role check (`/participants`, `/service-offerings`, `/resources` reject credentials whose subjects do not resolve to the matching role).
+
+A type URI not claimed by any bundle resolves to `ResolvedRole.UNKNOWN`; the credential is treated as a non-typed RDF claim set and routed accordingly.
+
+**Bundled framework — `gaia-x-2511`:**
+
+[options="header",cols="1,3"]
+|===
+| Field | Value
+| `id` | `gaia-x-2511`
+| `family` | `gaia-x`
+| `namespace` | `https://w3id.org/gaia-x/2511#`
+| `validation_type` | `shacl`
+| Declared roles | `Participant`, `ServiceOffering` (with `additional_roots: [DigitalServiceOffering]`), `Resource`
+|===
+
 [[_protected_namespace_filter]]
 ===== Protected Namespace Filter
 

--- a/federated-catalogue/src/docs/architecture/chapters/05_building_block_view.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/05_building_block_view.adoc
@@ -457,6 +457,21 @@ classDiagram
     }
 ....
 
+Validation results are persisted in the `validation_result` table.
+Results carry an `outdated` flag and an `OutdatedReason` that records why a result is no longer current:
+
+[options="header",cols="1,2"]
+|===
+| Reason | Trigger
+| `ASSET_UPDATED` | A new version of the asset was uploaded (`PUT /assets/{id}`)
+| `ASSET_REVOKED` | The asset was revoked (status transition to `REVOKED`)
+|===
+
+**Lifecycle rules:**
+
+* **Asset update / revoke:** All existing results for the asset are bulk-marked `outdated = true` with the appropriate `OutdatedReason`. Results are retained for audit purposes — historical validation state remains queryable.
+* **Asset delete:** All associated results are permanently deleted (`ValidationResultStore.deleteByAssetId`).
+
 ===== Revalidation Service
 
 This component periodically revalidates existing credentials. It checks if the signatures are still valid (e.g. not expired or referencing DID is still available). If the validation of a credential fails, it's either set to state _deprecated_ or _eol_. This will remove the credential from the Graph Database.

--- a/federated-catalogue/src/docs/architecture/chapters/08_concepts.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/08_concepts.adoc
@@ -31,6 +31,12 @@ The components use ```Slf4j``` for logging. ```Logback``` will be used as implem
 
 As default, all components should log to Standard out. Log aggregation is realized by the surrounding environment
 
+=== Trust Framework Bundles
+
+Each supported trust framework is delivered as a self-contained classpath bundle (`framework.yaml` + ontology + SHACL shapes) under `trustframeworks/<bundle-id>/`.
+A `TrustFrameworkRegistry` bean indexes all bundles at boot and resolves credential subject types to bundle-defined roles, replacing the previous hardcoded URI-to-enum mapping.
+See ADR 10 for the design rationale and <<_trust_framework_bundles_and_role_resolution,Building Block View — Trust Framework Bundles and Role Resolution>> for the runtime structure.
+
 === Admin Configuration Persistence
 
 Admin configuration is backed by two PostgreSQL tables. The `trust_frameworks` table holds structured trust framework definitions (columns: `id`, `name`, `service_url`, `api_version`, `timeout_seconds`, `enabled`, `created_at`, `updated_at`), seeded with a single Gaia-X entry. The `admin_config` table is a generic key-value store (`config_key` PK, `config_value`) for all other runtime settings:

--- a/federated-catalogue/src/docs/architecture/chapters/09_architecture_decisions.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/09_architecture_decisions.adoc
@@ -328,3 +328,112 @@ If a future 2511 spec version introduces `owl:equivalentClass`, `owl:intersectio
 * Non-Gaia-X VC 2.0 (`VC2_DANUBETECH`) intentionally bypasses Gaia-X type resolution — future trust framework support for non-Gaia-X federations will add pluggable type resolution.
 * The SRS preamble envisions the catalogue as a generic, trust-framework-agnostic metadata store. Removing a single legacy trust framework generation aligns with this direction — the catalogue's verification pipeline is designed to be pluggable, not permanently coupled to any specific Gaia-X release.
 
+=== ADR 10: Trust Framework Bundles and Dynamic Role Resolution
+
+**Related:** ADR 8, ADR 9
+
+**Context:** ADR 9 introduced per-format type URI resolution to handle the disconnected Tagus/Loire class hierarchies.
+The type URIs (`gx:Participant`, `gx:ServiceOffering`, `gx:Resource`) were carried in `application.yml` properties and mapped to a compile-time `TrustFrameworkBaseClass` enum.
+This design has two operational failure modes and one structural limit:
+
+1. **Sibling classes in the same ontology.** The Loire 2511 ontology places `gx:DigitalServiceOffering` as a direct child of `gx:GaiaXEntity` — not under `gx:ServiceOffering`.
+SPARQL `rdfs:subClassOf*` traversal from `gx:ServiceOffering` never reaches it.
+Credentials of type `gx:DigitalServiceOffering` (which has its own `sh:targetClass` SHACL shape and is a valid first-class credential type) were rejected with "no proper CredentialSubject found." The same problem recurs for any future sibling class.
+
+2. **Cannot support multiple trust frameworks.** The catalogue is intended to be a generic federated catalogue (Gaia-X, future Catena-X, others).
+Hardcoded Gaia-X URIs and a fixed Java enum cannot accommodate this without code changes per framework.
+
+3. **Wrong abstraction level.** `TrustFrameworkBaseClass.SERVICE_OFFERING` was a Gaia-X concept baked into the type system, API routing, and storage.
+It cannot meaningfully represent the equivalent concept in another trust framework, nor future Gaia-X classes that are siblings rather than subclasses of `gx:ServiceOffering`.
+
+Three options were considered:
+
+1. **Add more hardcoded URIs:** Add `gx:DigitalServiceOffering` as a second `service-offering.type` URI.
+Fixes DSO immediately but deepens every structural problem above.
+
+2. **SHACL-driven discovery, retain enum:** Replace hardcoded URIs with runtime discovery; keep `TrustFrameworkBaseClass` enum as the routing label.
+Fixes DSO and enables new frameworks via config, but the fixed enum still couples the API and storage schema to Gaia-X concepts.
+
+3. **Bundle-per-framework with explicit role declarations (chosen):** Each trust framework is a self-contained classpath bundle (ontology + SHACL + a YAML config that declares the framework's roles).
+At startup the catalogue loads all bundles, builds a `<typeUri> → <ResolvedRole>` index by walking each declared role's subclass closure, and routes credentials by role string.
+No trust-framework concept exists in Java source — only in the bundle configs.
+
+**Decision:** Option 3 — bundle-per-framework with explicit role declarations and dynamic subclass-closure indexing.
+
+**Bundle layout (classpath resources):**
+
+----
+trustframeworks/
+  <bundle-id>/
+    framework.yaml      # bundle metadata and role declarations
+    ontology.ttl        # OWL class hierarchy (optional for non-SHACL bundles)
+    shapes.ttl          # SHACL shapes (optional for non-SHACL bundles)
+----
+
+The `TrustFrameworkBundleLoader` scans `classpath:trustframeworks/*/framework.yaml` at boot.
+A bundle that fails to load is logged at WARN and skipped — it does not abort loading of remaining bundles.
+
+**`framework.yaml` format:**
+
+[source,yaml]
+----
+id: gaia-x-2511                          # framework profile id (registry key)
+family: gaia-x                           # framework family (groups related profiles)
+namespace: "https://w3id.org/gaia-x/2511#"
+validation_type: shacl                   # shacl | json-schema | unknown
+
+roles:
+  Participant:                           # role name = OWL local name; URI = namespace + roleName
+    additional_roots: [ ]                # extra URIs mapped to this role (non-OWL-subclass siblings)
+    types: [ ]                           # forward-compat for json-schema engines (unused for shacl)
+  ServiceOffering:
+    additional_roots:
+      - "https://w3id.org/gaia-x/2511#DigitalServiceOffering"
+    types: [ ]
+  Resource:
+    additional_roots: [ ]
+    types: [ ]
+
+properties: { }                          # framework-specific metadata (reserved)
+----
+
+**Role indexing (SHACL bundles):** For each declared role, the registry takes the root URI as `namespace + roleName`, then walks DOWN the OWL hierarchy in `ontology.ttl` via `rdfs:subClassOf*` and indexes every reachable class under that role.
+The optional `additional_roots` list adds non-subclass URIs (siblings, cross-hierarchy mappings) to the same role — this is the mechanism that maps `gx:DigitalServiceOffering` to the `ServiceOffering` role.
+Bundles whose `validation_type` is not `shacl` are loaded but deferred (no validation engine wired yet); a WARN is logged.
+
+**`TrustFrameworkRegistry` (new bean, registered by `TrustFrameworkRegistryConfig`):**
+
+* `resolveRole(typeUri): ResolvedRole` — returns `(frameworkProfileId, role)` for a credential subject's type URI, or `ResolvedRole.UNKNOWN` if no bundle claims the type
+* `getBundles()` / `getBundle(profileId)` — bundle lookup
+* `getEffectiveRoles(profileId)` — role set declared by a bundle
+* `isFrameworkEnabled(profileId)` — true for SHACL-active bundles
+
+**`TrustFrameworkBaseClass` enum:** removed.
+Call sites use `ResolvedRole` (a record carrying `frameworkProfileId: String` and `role: String`).
+Storage and API routing dispatch on the role string directly.
+The role names `Participant`, `ServiceOffering`, and `Resource` remain referenced as constants (`VerificationConstants.ROLE_*`) by the typed verification endpoints, but the bundle config — not Java source — is the authority for what roles exist.
+
+**`CredentialFormat`:** the existing `GAIAX_V2_LOIRE` / `VC2_DANUBETECH` enum continues to drive format detection (JWT structure, header validation, unwrapping).
+It is independent of role resolution: any credential whose subject type URI is registered by some bundle resolves to that bundle's role, regardless of which JWT format envelope carries it.
+
+**Multi-framework side-by-side:** Multiple bundles load simultaneously.
+Namespaces are disjoint by construction; resolution is unambiguous.
+A VP containing credentials from different frameworks routes each credential through its own bundle's role.
+Adding a new framework is a classpath-resource change — drop a new `trustframeworks/<bundle-id>/` directory containing `framework.yaml` plus the ontology/SHACL files; no Java changes.
+
+**Removed configuration:** the `federated-catalogue.verification.{participant,resource,service-offering}.type` properties (and the `service-offering.additional-types` workaround) are no longer read.
+Type URIs are now declared exclusively in each bundle's `framework.yaml`.
+
+**Out of scope for this ADR:**
+
+* JSON Schema validation engine wiring (bundles with `validation_type: json-schema` load but defer until the engine is integrated)
+* A second framework bundle delivered alongside the catalogue — the mechanism exists; only the `gaia-x-2511` bundle ships at present
+* A generic type-URI-based query API — the existing role-based endpoints (`/participants`, `/service-offerings`, `/resources`) cover current needs; future frameworks that define different role names can expose them via framework-specific endpoints or a generic type query
+
+**Rationale:**
+
+* Fully bundled framework definitions make adding `gx:DigitalServiceOffering` (or any future sibling) a one-line change in `framework.yaml` — no Java, no redeploy logic.
+* Removing the enum eliminates the architectural coupling between Gaia-X ontology structure and Java source; the verification pipeline is now a generic engine driven by bundle metadata.
+* Bundle-per-framework gives a clear extension point — a developer adding a new framework drops a directory; the registry treats it identically to the bundled one.
+* Explicit role declarations (rather than `sh:targetClass` auto-discovery) keep the bundle's public surface minimal and reviewable: a reader sees three role names, not the full transitive subclass closure.
+* Supersedes the hardcoded `loireBaseClassUris` / `legacyBaseClassUris` maps and `service-offering.type` / `participant.type` / `resource.type` properties introduced in ADR 9.

--- a/federated-catalogue/src/docs/architecture/chapters/12_glossary.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/12_glossary.adoc
@@ -90,4 +90,19 @@ The identifier must be a valid IRI (see ADR 7).
 |fcmeta:hasMachineReadable
 |RDF property in the protected `fcmeta:` namespace written to the graph DB when an asset link is created. Points from a human-readable asset's IRI to its machine-readable counterpart's IRI.
 
+|Trust Framework Bundle
+|A self-contained, classpath-loaded unit (`framework.yaml` + `ontology.ttl` + `shapes.ttl`) defining a single trust-framework profile. Discovered at boot under `trustframeworks/<bundle-id>/`. Indexed by `TrustFrameworkRegistry` to drive role resolution. See ADR 10.
+
+|Framework Profile (id)
+|Stable identifier of a single trust-framework bundle (e.g. `gaia-x-2511`). Acts as the registry key and the `frameworkProfileId` of every `ResolvedRole` it produces.
+
+|Framework Family
+|Grouping label shared by related profiles of the same framework lineage (e.g. all Gaia-X profiles share `family: gaia-x`). Reserved for future cross-version queries; not used for routing.
+
+|Role (Trust Framework)
+|A bundle-declared label (e.g. `Participant`, `ServiceOffering`, `Resource` for `gaia-x-2511`) mapped to a set of credential subject type URIs via OWL subclass closure plus optional `additional_roots`. Drives typed verification dispatch and the typed-endpoint expected-role check. Distinct from Keycloak user roles.
+
+|Resolved Role
+|A `(frameworkProfileId, role)` pair returned by `TrustFrameworkRegistry.resolveRole(typeUri)`. `ResolvedRole.UNKNOWN` represents a type not claimed by any loaded bundle.
+
 |===


### PR DESCRIPTION
## 🚀 Summary

Publishes ADR 10 ("Trust Framework Bundles and Dynamic Role Resolution") and documents the new `TrustFrameworkRegistry` runtime in the arc42 architecture.

## ✅ What's Changed

- [x] **ADR 10 published** - explicit role declarations + downward `rdfs:subClassOf*` walk + `additional_roots`, not `sh:targetClass` auto-discovery
- [x] **Building Block View** -  new `Trust Framework Bundles and Role Resolution` subsection inside the Verification Service, with class diagram and the `gaia-x-2511` bundle summary
- [x] **Cross-cutting Concepts** - new `Trust Framework Bundles` entry pointing at ADR 10 and the chapter-05 anchor
- [x] **Glossary** (`chapters/12_glossary.adoc`) - new entries: *Trust Framework Bundle*, *Framework Profile (id)*, *Framework Family*, *Role (Trust Framework)*, *Resolved Role*
- [x] Code formatted and linted — AsciiDoc style consistent with surrounding chapters

## 🧪 How to Test

Render the arc42 site and confirm ADR 10 appears in the chapter 09 TOC between ADR 9 and any later ADRs.

## 🔍 Related Issues

Related to ADR 9 (Loire 2511 ontology), ADR 8 (VC-JOSE-COSE)
describes https://github.com/federated-catalogue-enhancements-2026/federated-catalogue/pull/45

## 📋 Checklist

- [x] I've tested my code locally — verified all anchors and cross-references resolve; confirmed no stale draft/story references remain
- [x] I've updated documentation if necessary — this PR *is* the documentation update
- [x] My changes follow the project's coding style — AsciiDoc + Mermaid conventions match surrounding chapters; ADR 10 strips internal-only identifiers (no story IDs, no internal planning paths) per the design-documents publication rules
