### PR TITLE
docs(arc42): federated catalogue — content verification and decoupling sweep

### DIFF
--- a/federated-catalogue/README.md
+++ b/federated-catalogue/README.md
@@ -1,15 +1,24 @@
-# Architecture document for the GXFS Catalogue
-## XFSC Federated Catalogue
-The content of the document is available here
-* [PDF](
-https://gitlab.com/gaia-x/data-infrastructure-federation-services/cat/architecture-document/-/jobs/artifacts/main/raw/build/pdf/architecture/catalogue-architecture.pdf?job=generate_pdf)
-* [Website](https://gaia-x.gitlab.io/data-infrastructure-federation-services/cat/architecture-document/architecture/catalogue-architecture.html)
+# Architecture Document — XFSC Federated Catalogue
 
-## FACIS - XFSC Catalogue Enhancements
-The XFSC Federated Catalogue (CAT) manages metadata objects (typically credentials or other RDF descriptions, e.g., of Providers, their Service Offerings and Resources) throughout their life cycle and exposes them to Consumers. It enables verification of these objects against given schemas and/or trust anchors. 
+The architecture is built by
+the [buildDocs workflow](https://github.com/eclipse-xfsc/docs/actions/workflows/buildDocs.yml) in the
+`eclipse-xfsc/docs` repository. Each workflow run uploads a `Documentation.zip` artifact containing the rendered static
+HTML and PDF; download it from the "Artifacts" section of the most recent successful run.
 
-This enhancement of the CAT modularizes its verification of credentials against trust anchors and generalizes its management of metadata objects beyond the former focus on credentials; thus, it will also be able to function as a Template Repository for the FACIS Digital Contract Service (DCS).
+> TODO: replace the workflow-run download with a stable, versioned public URL (e.g. GitHub Pages or a release asset)
+> once that publication channel is in place.
 
-The enhanced specification document can be found here : [PDF](https://github.com/eclipse-xfsc/docs/blob/main/federated-catalogue/src/docs/CAT%20Enhancement/CAT_Enhancement_Specifications%20v1.0.pdf)
+## About the Catalogue
 
-The implementation of the federated catalogue can be found here : [`implementation/federated-catalogue`](https://github.com/eclipse-xfsc/federated-catalogue)
+The XFSC Federated Catalogue manages metadata objects — typically verifiable credentials or RDF descriptions of
+providers, service offerings, and resources — throughout their life cycle and exposes them to consumers. It verifies
+these objects against schemas and trust anchors.
+
+The current generation of the catalogue modularizes credential verification against trust anchors and generalizes
+metadata-object management beyond credentials, enabling reuse as a template repository for adjacent services.
+
+The full functional and non-functional specification is published in the same documentation repository and linked from
+the rendered website above.
+
+The reference implementation lives
+at [eclipse-xfsc/federated-catalogue](https://github.com/eclipse-xfsc/federated-catalogue).

--- a/federated-catalogue/src/docs/architecture/catalogue-architecture.adoc
+++ b/federated-catalogue/src/docs/architecture/catalogue-architecture.adoc
@@ -5,7 +5,7 @@
 //
 // ====================================
 
-= Architecture Gaia-X Federated Catalogue image:Federated-Catalogue.png[Federated Catalogue]
+= XFSC Federated Catalogue — Architecture image:Federated-Catalogue.png[Federated Catalogue]
 // toc-title definition MUST follow document title without blank line!
 :toc-title: Table of Contents
 :toclevels: 3

--- a/federated-catalogue/src/docs/architecture/chapters/01_introduction_and_goals.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/01_introduction_and_goals.adoc
@@ -39,7 +39,11 @@ Quality goals regarding, e.g., performance, safety, security, and standards conf
 | Participants in a Gaia-X ecosystem | n/a | Participants can interact with a Catalogue as expected.
 |===
 
-=== Assumptions (Original 2022 implementation)
+=== Assumptions
+
+NOTE: The assumptions below are **historical context** from the 2022 reference implementation, captured here so that present-day architecture choices remain understandable.
+Several of them no longer hold literally — Gaia-X has since matured (Loire 25.05 architecture, ICAM 24.07, 25.11 ontology), and the catalogue has generalised "Self-Description" to "Asset" and "Credential".
+Where a present-day statement contradicts an assumption below, the present-day statement (and the relevant ADR) wins.
 
 Since this project is conducted in an early stage of the Gaia-X development there is no experience how credentials (formerly called Self-Descriptions) will look like in practice. Therefore, several assumptions regarding their characteristics have to be made. These assumptions will be explained in this section.
 

--- a/federated-catalogue/src/docs/architecture/chapters/01_introduction_and_goals.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/01_introduction_and_goals.adoc
@@ -15,15 +15,14 @@ This document gives a short overview of the architectural design decisions for t
 
 === Requirements Overview
 
-The requirements for implementing the Gaia-X Federated Catalogue are given in its specification documentfootnote:[Gaia-X Federation Services. Core Catalogue Features. 2021. https://www.gxfs.eu/download/1740/]. Individual requirements were changed during the implementation in mutual agreement, for reasons including the following:
+The requirements for implementing the Federated Catalogue originate in its specification documentfootnote:[Gaia-X Federation Services. Core Catalogue Features. 2021. https://www.gxfs.eu/download/1740/], published as part of the GXFS programme from which XFSC emerged.
+Individual requirements were refined during implementation in mutual agreement, for reasons including the following:
 
 * The specification of a requirement turned out to be unsatisfiable for conceptual or practical reasons.
 * The understanding of an underlying concept had evolved during the further work of the Gaia-X Technical Committee and its working groups after the original publication of the requirements specification.
 
-The catalogue specification has been updated with new requirements, identified by IDs starting with CAT-FR-*.
-While these requirements are not fully implemented yet, they are planned to be completed by 2026.
-The catalogue's architecture is designed to support the implementation of these new requirements.
-In cases of conflict, the newer requirements take precedence over the older ones.
+The catalogue specification has since been extended by a successor set of functional and non-functional requirements (identified, in the SRS, by IDs beginning with `CAT-FR-` and `CAT-NFR-`).
+The architecture is designed to support these requirements; where they conflict with the original specification, the newer requirements take precedence.
 
 For more details, refer to the document "Enhancement of the XFSC Federated Catalogue" footnote:[Enhancement of the XFSC Federated Catalogue. 2025. https://github.com/eclipse-xfsc/docs/blob/9a178c30f76610e5924fd72c39d259d6a8ae0461/federated-catalogue/src/docs/CAT%20Enhancement/CAT_Enhancement_Specifications%20v1.0.pdf].
 
@@ -36,11 +35,11 @@ Quality goals regarding, e.g., performance, safety, security, and standards conf
 [options="header",cols="1,2,2"]
 |===
 |Role/Name|Contact|Expectations
-| leader and implementation partners of the GXFS project | https://gxfs.eu/ | The implementation conforms to the requirements, i.e., the functionality behind the interfaces is implemented as specified, thus facilitating integration of the Federated Catalogue with other Federation Services.  The architecture facilitates this conformance by bridging between the high level of the requirements specification and concrete design and implementation choices.
+| Original specification authors (GXFS programme, 2021–2024) | https://gxfs.eu/ | The implementation conforms to the requirements, i.e., the functionality behind the interfaces is implemented as specified, thus facilitating integration of the Federated Catalogue with other Federation Services. The architecture facilitates this conformance by bridging between the high level of the requirements specification and concrete design and implementation choices.
 | Participants in a Gaia-X ecosystem | n/a | Participants can interact with a Catalogue as expected.
 |===
 
-=== Assumptions
+=== Assumptions (Original 2022 implementation)
 
 Since this project is conducted in an early stage of the Gaia-X development there is no experience how credentials (formerly called Self-Descriptions) will look like in practice. Therefore, several assumptions regarding their characteristics have to be made. These assumptions will be explained in this section.
 

--- a/federated-catalogue/src/docs/architecture/chapters/02_architecture_constraints.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/02_architecture_constraints.adoc
@@ -11,6 +11,10 @@ ifndef::imagesdir[:imagesdir: ../../images]
 [[section-architecture-constraints]]
 == Architecture Constraints
 
-The constraints are written in the specification of the Federated Catalogue.
+The detailed constraints on the Federated Catalogue (functional and non-functional requirements, quality scenarios, compliance obligations) are owned by the Software Requirements Specification and the successor "XFSC Federated Catalogue Enhancement" document, not restated here.
+This chapter records only the cross-cutting constraints that shape every architectural decision below.
 
-One main requirement to mention at this place is the requirement that all used components must be compliant with https://www.apache.org/licenses/LICENSE-2.0[Apache License, Version 2.0]
+* **License.** All components used by the Federated Catalogue must be compatible with the https://www.apache.org/licenses/LICENSE-2.0[Apache License, Version 2.0].
+This rules out copyleft-licensed dependencies for embedded use.
+* **Target trust framework.** The current implementation is maintained against Gaia-X Loire (see ADR 9 and the NOTE in chapter <<section-solution-strategy>>); compliance with Loire is therefore an architectural constraint, not a per-deployment choice.
+* **Federated context.** The catalogue runs in a federated ecosystem spanning operators, jurisdictions, and time zones; design decisions must not assume a single authoritative deployment, single trust anchor, or single time zone.

--- a/federated-catalogue/src/docs/architecture/chapters/03_system_scope_and_context.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/03_system_scope_and_context.adoc
@@ -9,6 +9,12 @@ ifndef::imagesdir[:imagesdir: ../../images]
 :toc:
 
 [[section-system-scope-and-context]]
+== System Scope and Context
+
+The Federated Catalogue is a federation-services component: it is operated by one party (the *Federator*) and consumed by many (Participants in the federation, acting in Provider or Consumer roles).
+It does not have a direct end-user interface — clients interact with it through a Portal or through their own services that speak the catalogue's API.
+The technical deployment topology, including the surrounding Keycloak, PostgreSQL, and graph store, is described in <<section-deployment-view>>.
+
 === Business Context
 The following table shortly lists the Stakeholders for the federated catalogue:
 

--- a/federated-catalogue/src/docs/architecture/chapters/03_system_scope_and_context.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/03_system_scope_and_context.adoc
@@ -16,12 +16,17 @@ The following table shortly lists the Stakeholders for the federated catalogue:
 |===
 | Stakeholder | Description
 | Federator | Responsible for operating the Federated Catalogue.
-| Participant (in a Federation), typically in the Provider role | Onboarded entity, according to http://docs.gaia-x.eu/technical-committee/architecture-document/latest/conceptual_model/#participants[this] definition. A Participant has a Gaia-X credential.
+| Participant (in a Federation), typically in the Provider role | Onboarded entity, according to https://docs.gaia-x.eu/technical-committee/architecture-document/25.05/trust_framework_architecture/#definitions[this] definition. A Participant has a Gaia-X credential.
 | Provider | Special type of _Participant_, who might submit credentials to the Catalogue.
 | Consumer | Special type of _Participant_, who can consume services in Gaia-X
 | User | Usually a person action on behalf of a _Participant_. A users interacts (maybe with the help of other components, like the portal) with the federated catalogue. The accessible endpoints depend on the rule, a user has.
 |===
 
-More information can be found in the http://docs.gaia-x.eu/technical-committee/architecture-document/latest/[Gaia-X Architecture document].
+More information can be found in the https://docs.gaia-x.eu/technical-committee/architecture-document/25.05/[Gaia-X Architecture Document — Loire 25.05].
+
+NOTE: The Gaia-X document set releases its sub-documents on independent version tracks.
+For the Loire release these are: **Architecture 25.05**, **Compliance 25.10**, **ICAM 24.07**, **Data Exchange 25.07**, **Ontology 25.11** (source: https://docs.gaia-x.eu/).
+External Gaia-X links throughout this document are intentionally pinned to the corresponding Loire-track version per sub-document.
+Do **not** rewrite them to `/latest/`: a future Gaia-X release would silently change the reader's interpretation of statements authored against Loire.
 
 

--- a/federated-catalogue/src/docs/architecture/chapters/04_solution_strategy.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/04_solution_strategy.adoc
@@ -15,7 +15,13 @@ This chapter describes some basic concepts and details, when handling credential
 
 === Credentials
 
-NOTE: In 2026 what was previously called "Self-Description" has been renamed to **Credential**footnote:[https://docs.gaia-x.eu/technical-committee/identity-credential-access-management/24.07/credential_format/[Gaia-X Identity, Credential and Access Management / Credential format]] — a Verifiable Presentation (VP) containing one or more Verifiable Credentials (VCs), or a standalone VC, that describes a trust framework entity. At the catalogue's API and storage level, the generic term **Asset** is used to also describe non-RDF content that can be used in the lenient default configuration, not requiring verification. This section uses "credential" to describe the original domain concept that is still available in the strict configuration profile of the catalogue.
+NOTE: What earlier Gaia-X generations called a "Self-Description" has been renamed to **Credential**footnote:[https://docs.gaia-x.eu/technical-committee/identity-credential-access-management/24.07/credential_format/[Gaia-X Identity, Credential and Access Management 24.07 (Loire) / Credential format]] — a Verifiable Presentation (VP) containing one or more Verifiable Credentials (VCs), or a standalone VC, that describes a trust-framework entity.
+At the catalogue's API and storage level, the generic term **Asset** also covers non-RDF content that can be used in the lenient default configuration without verification.
+This section uses "credential" to describe the original domain concept that remains available in the strict configuration profile.
+
+NOTE: **Target Gaia-X release.** The current implementation has been written and is maintained against the **Gaia-X Loire** trust framework (ICAM 24.07).
+The next Gaia-X release (Danube) is **not yet supported**; ADR 17 describes the planned migration path.
+Where Java identifiers in this document or in the source tree contain the word `danubetech` (e.g. `Vc2DanubeTechCredentialProcessor`, the `VC2_DANUBETECH` format enum value), they refer to the https://danubetech.com/[danubetech] open-source Java library used to parse generic W3C VC 2.0 credentials — they are unrelated to the Gaia-X "Danube" release.
 
 ==== Granularity of Credentials
 
@@ -48,11 +54,12 @@ When content is submitted, an `RdfDetector` component classifies it as either RD
 * **RDF content** (e.g., `application/ld+json`, or `application/json` with an `@context` key) follows the existing verification pipeline: syntax check, semantic validation, claim extraction, graph storage.
 * **Non-RDF content** (e.g., `application/pdf`, `text/plain`, `application/octet-stream`, plain JSON without `@context`) bypasses verification entirely and is stored directly in the File Store with metadata in the Metadata Store. No claims are extracted and no graph database interaction occurs.
 
-The set of MIME types treated as RDF is configurable via `federated-catalogue.rdf.content-types`. Operators can adjust this allowlist to match their deployment's verification capabilities.
+The set of MIME types treated as RDF is configurable; operators can adjust the allowlist to match their deployment's verification capabilities (see the operator guide).
 
 ==== Asset IRI Assignment
 
-Every asset in the catalogue MUST be identified by an IRI, in compliance with requirement CAT-FR-AM-02: Each Asset MUST be identified by an IRI. DIDs and UUIDs as URNs (RFC 4122) MUST be supported.footnote:[Enhancement of the XFSC Federated Catalogue. 2025. https://github.com/eclipse-xfsc/docs/blob/9a178c30f76610e5924fd72c39d259d6a8ae0461/federated-catalogue/src/docs/CAT%20Enhancement/CAT_Enhancement_Specifications%20v1.0.pdf]. The supported IRI formats are:
+Every asset in the catalogue is identified by an IRI.
+The supported IRI formats are:
 
 * **DIDs** — e.g., `did:web:example.com`, `did:key:z6Mk...` (extracted from RDF credential content)
 * **UUID URNs** — e.g., `urn:uuid:550e8400-e29b-41d4-a716-446655440000` (generated per RFC 4122footnote:[https://www.rfc-editor.org/rfc/rfc4122[RFC 4122 — A Universally Unique IDentifier (UUID) URN Namespace]])
@@ -64,11 +71,15 @@ IRI assignment is handled by the `IriGenerator` component and validated by the `
 * **RDF assets (credentials):** The IRI is extracted from the content — `credentialSubject.id` for Verifiable Credentials, or `@id` for generic JSON-LD. OWL ontologies, SHACL shapes, and SKOS concept schemes use their respective root identifiers. If no IRI can be extracted, a UUID URN is generated as fallback.
 * **Non-RDF assets:** A UUID URN (`urn:uuid:...`) is generated automatically. Each upload receives a unique identifier per RFC 4122.
 
-All IRIs are validated on assignment. Invalid formats (null, blank, or syntactically malformed) are rejected. Duplicate content detection still applies — uploading the same content twice results in a conflict (HTTP 409), with the existing IRI returned in the error response.
+All IRIs are validated on assignment.
+Invalid formats (null, blank, or syntactically malformed) are rejected.
+Duplicate content detection still applies — uploading the same content twice is rejected as a conflict, with the existing IRI returned in the error response (see the OpenAPI specification for the exact contract).
 
 ==== Storage Strategy
 
-Non-RDF assets are stored in a dedicated File Store instance (`assetFileStore`), separate from the schema and context caches. Asset metadata (content type, file size, original filename) is stored in the `assets` table (renamed from `sdfiles`) with three additional columns. The `content` column is nullable — for non-RDF assets, the raw bytes live only in the File Store, not in the database.
+Non-RDF assets are stored in a dedicated File Store instance, separate from the schema and context caches.
+Asset metadata (content type, file size, original filename) is persisted in the metadata store.
+For non-RDF assets, the raw bytes live only in the File Store, not in the relational database.
 
 === Asset Taxonomy and Claim Naming
 

--- a/federated-catalogue/src/docs/architecture/chapters/04_solution_strategy.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/04_solution_strategy.adoc
@@ -11,13 +11,17 @@ ifndef::imagesdir[:imagesdir: ../../images]
 [[section-solution-strategy]]
 == Solution Strategy
 
-This chapter describes some basic concepts and details, when handling credentials and Schemas. They are needed to understand the details.
+This chapter introduces the design concepts that the rest of the document builds on: how the catalogue thinks about credentials and assets, how content arrives at the upload endpoint, how identifiers are assigned, and how schemas are categorised.
+Detailed building blocks (verification pipeline, graph store, admin API) follow in <<section-building-block-view>>; runtime flows are in chapter 6; the deployment surface is in chapter 7.
+
+TIP: Terms used here that are not introduced inline (Asset, Trust Framework Bundle, Base Class, Loire, Tagus, ICAM, EVC/EVP, on-demand validation) are defined in the <<section-glossary,Glossary>>.
 
 === Credentials
 
 NOTE: What earlier Gaia-X generations called a "Self-Description" has been renamed to **Credential**footnote:[https://docs.gaia-x.eu/technical-committee/identity-credential-access-management/24.07/credential_format/[Gaia-X Identity, Credential and Access Management 24.07 (Loire) / Credential format]] — a Verifiable Presentation (VP) containing one or more Verifiable Credentials (VCs), or a standalone VC, that describes a trust-framework entity.
-At the catalogue's API and storage level, the generic term **Asset** also covers non-RDF content that can be used in the lenient default configuration without verification.
-This section uses "credential" to describe the original domain concept that remains available in the strict configuration profile.
+At the catalogue's API and storage level, the generic term **Asset** also covers non-RDF content (PDFs, plain JSON, XML, binaries) that can be uploaded without going through the full verification pipeline — see <<_non_rdf_assets>> below.
+The catalogue ships two deployment profiles: a **lenient default profile** that runs only semantic validation and stores anything else as-is, and a **strict profile** that enables the full Gaia-X verification pipeline; both are introduced in <<_verification_profiles,chapter 5>>.
+This section uses "credential" to describe the original domain concept that remains available in the strict profile.
 
 NOTE: **Target Gaia-X release.** The current implementation has been written and is maintained against the **Gaia-X Loire** trust framework (ICAM 24.07).
 The next Gaia-X release (Danube) is **not yet supported**; ADR 17 describes the planned migration path.
@@ -66,7 +70,8 @@ The supported IRI formats are:
 * **Generic URNs** — e.g., `urn:nid:nss`
 * **HTTP/HTTPS IRIs** — e.g., `https://example.org/resource/123`
 
-IRI assignment is handled by the `IriGenerator` component and validated by the `IriValidator` component (see <<section-building-block-viev>>). The assignment strategy depends on the asset type:
+IRI assignment is handled by the `IriGenerator` component and validated by the `IriValidator` component (see <<section-building-block-view>>).
+The assignment strategy depends on the asset type:
 
 * **RDF assets (credentials):** The IRI is extracted from the content — `credentialSubject.id` for Verifiable Credentials, or `@id` for generic JSON-LD. OWL ontologies, SHACL shapes, and SKOS concept schemes use their respective root identifiers. If no IRI can be extracted, a UUID URN is generated as fallback.
 * **Non-RDF assets:** A UUID URN (`urn:uuid:...`) is generated automatically. Each upload receives a unique identifier per RFC 4122.

--- a/federated-catalogue/src/docs/architecture/chapters/05_building_block_view.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/05_building_block_view.adoc
@@ -107,7 +107,9 @@ The graph database backend is **pluggable**. Three adapters are available:
 | `NONE` | No-op / disabled | —
 |===
 
-All three adapters are wired unconditionally at boot. A single `RoutingGraphStore` (marked `@Primary`) holds the currently-active adapter behind a volatile reference and delegates every `GraphStore` call to it. Core services contain no backend-specific logic; they depend on `GraphStore` only.
+All three adapters are wired unconditionally at boot.
+A single `RoutingGraphStore` (marked `@Primary`) holds the currently-active adapter behind a volatile reference and delegates every `GraphStore` call to it; core services contain no backend-specific logic and depend on `GraphStore` only.
+The full description of the `GraphStore` interface and the routing-store behaviour lives in <<_graph_store,Graph Store>> further down this chapter.
 
 The active backend is resolved on cold boot in the following order:
 
@@ -175,7 +177,7 @@ a| Responsible for applying the defined verification rules on credentials (Verif
 * **Verification pipeline:** Syntactic, semantic, and cryptographic verification of credentials. The credential is checked as a whole — if VC verification fails, the entire verification fails.
 * **Strategy pattern:** `VerificationServiceImpl` acts as a thin Context that delegates to one of two `RdfIngestionStrategy` implementations — `CredentialVerificationStrategy` (recognised credentials and ambiguous JWTs) or `NonCredentialIngestionStrategy` (plain RDF payloads ingested as raw triples).
 * **Format detection:** `CredentialFormatDetector` classifies incoming RDF content by iterating an ordered chain of `CredentialFormatProcessor` beans. Recognized credential formats (Loire JWT, VC 2.0) enter the credential verification pipeline. Content classified as `UNKNOWN` (no recognized credential format) is routed to `NonCredentialIngestionStrategy`, which delegates triple extraction to `ClaimExtractionService.extractAllTriples()`. See <<_format_detection>>.
-* **Non-credential RDF extraction:** For RDF assets that are not Gaia-X Credentials, `NonCredentialIngestionStrategy` extracts all triples using Apache Jena via `ClaimExtractionService`. Supports JSON-LD, Turtle, N-Triples, and RDF/XML via a format fallback sequence. Returns a `NonCredentialVerificationResult` containing all extracted `RdfClaim` instances. See <<_non_credential_rdf_extraction>>.
+* **Non-credential RDF extraction:** For RDF assets that are not Gaia-X Credentials, `NonCredentialIngestionStrategy` extracts all triples using Apache Jena via `ClaimExtractionService`. Supports JSON-LD, Turtle, N-Triples, and RDF/XML via a format fallback sequence. Returns a `NonCredentialVerificationResult` containing all extracted claims (each one a subject–predicate–object triple, modelled by the `RdfClaim` record described under <<_claim>> below). See <<_non_credential_rdf_extraction>>.
 * **JWT content preprocessing:** `JwtContentPreprocessor` detects JWT-wrapped credentials using a two-signal approach (Content-Type header as primary signal, body prefix as fallback) and unwraps the JWT envelope to produce JSON-LD for downstream processing. See <<_jwt_content_preprocessing>>.
 * **JWT signature verification:** `JwtSignatureVerifier` verifies compact JWT signatures by resolving the issuer's DID document, matching `kid` to an `assertionMethod` verification method, and cryptographically verifying the JWS. Also verifies inner VC JWTs from `EnvelopedVerifiableCredential` entries in VP JWTs. See <<_jwt_signature_verification>>.
 * **Loire JWT parsing:** `LoireJwtParser` decodes Loire-format JWTs where the credential is the top-level JWT payload (no `vc`/`vp` claim wrapper), conforming to ICAM v24.07. See <<_loire_jwt_parsing>>.
@@ -291,7 +293,7 @@ classDiagram
     }
 ....
 
-The single `CredentialVerificationResult` type carries the resolved base class (e.g. `Participant`, `ServiceOffering`, `Resource` for the `gaia-x-2511` bundle) as a string field populated from `ResolvedBaseClass.baseClass`.
+The single `CredentialVerificationResult` type carries the resolved base class (e.g. `Participant`, `ServiceOffering`, `Resource` for the `gaia-x-2511` bundle) as a string field populated from `ResolvedBaseClass.baseClass`. *Base class* and *trust-framework bundle* are introduced in <<_trust_framework_bundles_and_base_class_resolution,Trust Framework Bundles and Base-class Resolution>> below; in short, a base class is a top-level credential-subject type declared by a trust-framework bundle (e.g. *Participant* in Gaia-X), and the resolved value drives dispatch and validator selection.
 Typed result subclasses (`CredentialVerificationResultParticipant`, `…Offering`, `…Resource`) and the deprecated schema-validation overloads have been removed; callers use `SchemaValidationService` directly for schema validation.
 
 [#_verification_strategy_pattern]

--- a/federated-catalogue/src/docs/architecture/chapters/05_building_block_view.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/05_building_block_view.adoc
@@ -11,7 +11,9 @@ ifndef::imagesdir[:imagesdir: ../../images]
 [[section-building-block-viev]]
 
 == Overall System overview
-This document describes the architecture of the Federated Catalogue, a component inside the Gaia-X Ecosystem. It is a component of the Gaia-X Federation Services defined by the GXFS-DE project.
+
+This document describes the architecture of the Federated Catalogue, a component of the XFSC stack within the Gaia-X ecosystem.
+It originates in the Gaia-X Federation Services originally defined by the GXFS programme (2021–2024); see the glossary entry for GXFS / XFSC.
 
 The Federated Catalogue is used to store and index assets (including credentials and non-RDF files) and to answer queries over this index. The basic integration into the Federation Services is shown in <<system_overview>>.
 
@@ -54,7 +56,9 @@ The architecture of the core component is described in the next sections.
 
 ==== Authentication
 
-The authentication component is responsible for authenticating users. This is not a central component of the catalogue, as it will be implemented by Lot 1 "Authentication & Authorization" of the GXFS-DE project. For the catalogue implementation, a mock integration is shown, using common, off the shelf software that implements the OpenID Connect standardfootnote:[https://openid.net/connect/[OpenID Connect]].
+The authentication component is responsible for authenticating users.
+It is not a central component of the catalogue itself; the original GXFS programme delivered it in a sibling lot ("Authentication & Authorization") and the same separation is preserved in XFSC.
+For the catalogue implementation, a mock integration is shown, using common, off-the-shelf software that implements the OpenID Connect standardfootnote:[https://openid.net/connect/[OpenID Connect]].
 
 The responsibilities of the authentication components are:
 
@@ -97,11 +101,12 @@ All three adapters are wired unconditionally at boot. A single `RoutingGraphStor
 
 The active backend is resolved on cold boot in the following order:
 
-. `admin_config[graphstore.preferred.backend]` — the persisted preference set by a prior admin switch.
-. `graphstore.impl` configuration property — the deployment-time bootstrap.
-. `NONE` — fallback so the application boots even without a configured graph store.
+. The persisted preference set by a prior admin switch.
+. The deployment-time bootstrap configuration.
+. A no-op fallback so the application boots even without a configured graph store.
 
-Per-backend connection URIs (`graphstore.neo4j.uri`, `graphstore.fuseki.uri`) are both read at startup so a switch can target either backend without configuration changes. Each adapter opens a driver lazily on first use, so an unreachable backend at boot does not prevent the application from starting.
+Per-backend connection URIs for both Neo4j and Fuseki are read at startup so a switch can target either backend without configuration changes.
+Each adapter opens a driver lazily on first use, so an unreachable backend at boot does not prevent the application from starting.
 
 Operators change the active backend through the Admin API (see <<_admin_api>>). The change takes effect in process on the next call — no JVM restart.
 
@@ -124,13 +129,15 @@ We chose not to implement a workaround that involves query rewriting, as this ma
 
 The Fuseki backend uses Apache Jena with RDF-star.
 Claims are stored as RDF-star triple nodes: `<<( subject predicate object )>> cred:credentialSubject credentialSubjectUri`.
-Queries must use SPARQL-star syntax (RDF 1.2 `<<( )>>` syntax, as supported by Jena 5.5+).
+Queries must use SPARQL-star syntax (RDF 1.2 `<<( )>>` syntax).
 Results are shuffled unless the query contains an `ORDER BY` clause.
 
 ==== File Store
 The File Store is responsible to persist all file based content submitted to the catalogue. These are credentials (Verifiable Presentations or standalone Verifiable Credentials), Schemas, and non-RDF assets.
 
-Non-RDF assets are stored in a dedicated File Store instance (`assetFileStore`), configured via `federated-catalogue.file-store.asset.location`. This keeps asset blobs separate from schema definitions and context caches for operational clarity. In production (`scope=runtime`), the asset location must be explicitly configured; the application fails to start if it is missing.
+Non-RDF assets are stored in a dedicated File Store instance, kept separate from schema definitions and context caches for operational clarity.
+In production the asset-store location must be explicitly configured; the application fails to start if it is missing.
+The exact configuration property is documented in the wiki configuration guide.
 
 For the sake of simplicity, a folder in the file system is used as file store. For future scalability the file store can be simply realized using an Object Storage or Database.
 
@@ -182,7 +189,7 @@ NOTE: Non-RDF schemas (JSON Schema, XML Schema) bypass the Schema Store entirely
 | RDF Detector | Classifies uploaded content as RDF or non-RDF based on a configurable MIME type allowlist and content inspection. For `application/json`, the detector checks for a JSON-LD `@context` key to distinguish JSON-LD (RDF) from plain JSON (non-RDF). Note that `application/schema+json` (JSON Schema) and `application/xml` (XSD) are always classified as non-RDF — even though they are schema formats, they are not RDF and do not enter the RDF verification pipeline.
 | Asset Upload Service | Orchestrates the dual-path upload flow: extracts request data, delegates to `RdfDetector` for classification, then routes to either the verification pipeline (RDF) or direct asset storage (non-RDF).
 | Asset Link Service | Manages bidirectional links between machine-readable (RDF) assets and human-readable representations (e.g., PDF, DOCX). Link metadata is stored directly on the `assets` table via an `asset_type` column and a `linked_asset_id` FK; supplementary `fcmeta:hasHumanReadable` / `fcmeta:hasMachineReadable` RDF triples are written to the graph DB.
-| Validation Result Storage | Persists the outcome of on-demand asset validation. Each `ValidationResult` record is stored in PostgreSQL (`validation_result` table) and projected as `fcmeta:` triples in the graph store (`SYNCED`/`FAILED`). Retrieval is exposed via `GET /assets/{id}/validations` (paginated) and `GET /validations/{id}`. After a graph backend reset, `GraphRebuilder.rebuildValidationResults()` re-projects all records from PostgreSQL.
+| Validation Result Storage | Persists the outcome of on-demand asset validation. Each result is stored in the relational metadata store and projected as `fcmeta:` triples into the graph store, with a graph-projection status that marks each row as synced or failed. Retrieval (paginated per asset, and single-row retrieval by surrogate identifier) is exposed via the validation endpoints defined in the OpenAPI specification. After a graph-backend reset, the rebuilder re-projects all stored records from the relational store.
 | Metadata Store | Database keeping all the required metadata for the modules. The Metadata Store is _owned_ by the _Store_ components. For separation, each component gets its own set of tables with no relation between them.
 | File Store | Storage system for persisting files (e.g., file system or object store/DB). Separate instances exist for schemas/contexts and for non-RDF assets.
 |===
@@ -396,7 +403,7 @@ After the strategy returns, the service performs one last cross-cutting check: i
 
 `CredentialVerificationStrategy` implements the credential pipeline — format dispatch, JWT signature verification (delegated to the matching `CredentialFormatProcessor`), Loire policy enforcement (`LoirePolicyEnforcer`), EVC/EVP unwrap and inner-VC verification (`EnvelopedCredentialResolver`), JSON-LD unwrap, semantic and schema validation, claim extraction, and protected-namespace filtering.
 `NonCredentialIngestionStrategy` extracts every triple from a plain RDF body via `ClaimExtractionService.extractAllTriples`, applies the protected-namespace filter, and returns a `NonCredentialVerificationResult` — no semantic, schema, or signature verification (those concepts only apply to credentials).
-Both strategies apply `ProtectedNamespaceFilter.filterClaims()` before returning and propagate filter warnings to the result; the `RdfIngestionStrategy` interface Javadoc documents the namespace-filtering requirement (CAT-FR-GD-09) for all implementations.
+Both strategies apply the protected-namespace filter before returning and propagate filter warnings to the result; the ingestion-strategy interface documents the namespace-filtering requirement for all implementations.
 
 `LoireCredentialProcessor` (`@Order(1)`) is the first processor in the chain.
 A credential is Loire if its JWT `typ` header is a Loire value (`vc+jwt`, `vc+ld+json+jwt`, `vp+jwt`, `vp+ld+jwt`) **and** the payload carries a top-level `@context` without a `vc`/`vp` wrapper claim; a contradictory payload (Loire `typ` plus a wrapper claim) is explicitly rejected as `UNKNOWN` so it cannot fall through to the generic VC 2.0 path.
@@ -558,8 +565,8 @@ The filter is applied at three ingestion boundaries:
 |===
 | Boundary | Integration point
 | Credential upload and claim extraction | `CredentialVerificationStrategy.ingest()` — explicitly calls `filterClaims()` after claim extraction; propagates filter warnings to `CredentialVerificationResult.warnings`.
-| Schema import and update (`POST /schemas`, `PUT /schemas/{id}`) | `SchemaStoreImpl.analyzeSchema()` — calls `filterModel()` on the parsed Jena RDF model before schema analysis proceeds; propagates filter warnings to `SchemaResult.warnings` in the API response.
-| Graph rebuild (`POST /actuator/graph-rebuild`) | `GraphRebuilder.addAssetToGraph()` — explicitly calls `filterClaims()` after re-extracting claims from stored credentials, ensuring the rebuilt graph is clean.
+| Schema import and update | `SchemaStoreImpl.analyzeSchema()` — calls the protected-namespace filter on the parsed Jena RDF model before schema analysis proceeds; propagates filter warnings to the schema result in the API response.
+| Graph rebuild | `GraphRebuilder.addAssetToGraph()` — explicitly applies the protected-namespace filter after re-extracting claims from stored credentials, ensuring the rebuilt graph is clean.
 |===
 
 [mermaid, width=2000]
@@ -588,32 +595,19 @@ classDiagram
     ProtectedNamespaceFilter ..> FilteredModel : returns
 ....
 
-Configuration:
-
-[options="header",cols="2,2,3"]
-|===
-| Property | Default | Description
-| `federated-catalogue.verification.protected-namespace.namespace` | `https://projects.eclipse.org/projects/technology.xfsc/federated-catalogue/meta#` | Namespace URI to protect. Normalized on startup: whitespace trimmed; `#` appended if the URI ends with neither `#` nor `/`.
-| `federated-catalogue.verification.protected-namespace.prefix` | `fcmeta` | Short prefix used in log output when reporting filtered triples.
-|===
+The protected-namespace URI and its log-output prefix are operator-configurable so custom deployments can substitute their own metadata namespace; the bundled default points the namespace at the XFSC federated-catalogue meta-namespace under `projects.eclipse.org`, with `fcmeta` as the prefix.
 
 [NOTE]
 ====
 Filtering is unconditional. There is no configuration toggle to disable it. The namespace URI is configurable to support custom deployments, but the filter itself is always active.
 
-Internal services bypass the filter by writing directly to `GraphStore.addClaims()`, which does not pass through the verification pipeline.
+Internal services bypass the filter by writing directly to the graph store, which does not pass through the verification pipeline.
 ====
 
 [#_upload_schema_validation_configuration]
 ===== Schema Validation Configuration
 
-Automatic SHACL schema validation during asset upload is disabled by default. This behavior is controlled by the `schema` verification property.
-
-[options="header",cols="2,1,3"]
-|===
-| Property | Default | Description
-| `federated-catalogue.verification.schema` | `false` | Enable/disable automatic SHACL schema validation during asset upload.
-|===
+Automatic SHACL schema validation during asset upload is disabled by default; an operator-controlled boot-time switch enables it (see the wiki configuration guide for the exact property name).
 
 **When disabled (default):**
 
@@ -629,7 +623,8 @@ Automatic SHACL schema validation during asset upload is disabled by default. Th
 [#_schema_validation_service]
 ===== Schema Validation Service
 
-Automatic schema validation in the upload verification flow is **configurable and disabled by default** (`federated-catalogue.verification.schema=false`). When enabled, upload verification delegates SHACL checks to `SchemaValidationService`; on-demand validation of stored assets is handled by `AssetValidationService` (see <<_on_demand_asset_validation>>).
+Automatic schema validation in the upload verification flow is **configurable and disabled by default**.
+When enabled, upload verification delegates SHACL checks to `SchemaValidationService`; on-demand validation of stored assets is handled by `AssetValidationService` (see <<_on_demand_asset_validation>>).
 
 [mermaid, width=2000]
 ....
@@ -646,7 +641,8 @@ classDiagram
 [#_on_demand_asset_validation]
 ===== On-Demand Asset Validation Service
 
-`AssetValidationService` provides on-demand validation of stored assets against registered validators, invoked via `POST /assets/validate`. It supports RDF assets (JSON-LD, Turtle, N-Triples, RDF/XML, Loire JWT), plain JSON assets, and XML assets.
+`AssetValidationService` provides on-demand validation of stored assets against registered validators, invoked via the dedicated on-demand validation endpoint defined in the OpenAPI specification.
+It supports RDF assets (JSON-LD, Turtle, N-Triples, RDF/XML, Loire JWT), plain JSON assets, and XML assets.
 
 Validation is delegated to a list of `ValidationStrategy` implementations selected by asset type:
 
@@ -663,22 +659,18 @@ Both paths run the engine in-line on the request thread.
 
 RDF asset content is parsed by `RdfAssetParser`, which unwraps Loire JWTs before parsing and delegates format detection to `CredentialFormatDetector` (JSON-LD, Turtle, N-Triples, RDF/XML). Validation results are persisted via `ValidationResultStore` (see <<_validation_result_storage>>).
 
-Multi-asset requests (`assetIds` with more than one entry) are restricted to SHACL validation: all asset models are merged into a single data graph before evaluation. Single-asset requests dispatch to all applicable enabled strategies. The maximum number of assets per request is controlled by `federated-catalogue.validation.max-assets-per-request` (default: 20).
+Multi-asset requests (more than one asset identifier in the request) are restricted to SHACL validation: all asset models are merged into a single data graph before evaluation.
+Single-asset requests dispatch to all applicable enabled strategies.
+The maximum number of assets per request is operator-configurable; see the wiki configuration guide for the property name and current default.
 
-Validation results are persisted in the `validation_result` table.
-Results carry an `outdated` flag and an `OutdatedReason` that records why a result is no longer current:
-
-[options="header",cols="1,2"]
-|===
-| Reason | Trigger
-| `ASSET_UPDATED` | A new version of the asset was uploaded (`PUT /assets/{id}`)
-| `ASSET_REVOKED` | The asset was revoked (status transition to `REVOKED`)
-|===
+Validation results are persisted in the relational store and carry an outdated flag together with a reason that records why a result is no longer current.
+The two recognised reasons are an asset update (a new asset version has been uploaded) and an asset revocation (the asset has transitioned to the revoked lifecycle state).
 
 **Lifecycle rules:**
 
-* **Asset update / revoke:** All existing results for the asset are bulk-marked `outdated = true` with the appropriate `OutdatedReason`. Results are retained for audit purposes — historical validation state remains queryable.
-* **Asset delete:** All associated results are permanently deleted (`ValidationResultStore.deleteByAssetId`).
+* **Asset update / revoke:** All existing results for the asset are bulk-marked as outdated with the appropriate reason.
+Results are retained for audit purposes — historical validation state remains queryable.
+* **Asset delete:** All associated results are permanently deleted.
 
 ===== Revalidation Service
 
@@ -703,9 +695,9 @@ Blank nodes are handled via Jena's built-in blank-node representation.
 Extracted claims pass through `ProtectedNamespaceFilter.filterClaims()` and the result is a `NonCredentialVerificationResult` — a subclass of `CredentialVerificationResult` with `issuer`, `issuanceDate`, and `credentialId` set to `null` (absent from non-credential RDF documents).
 A payload that contains no triples is rejected with a 400 (`"Non-credential RDF content contains no triples"`).
 
-NOTE: SHACL schema validation is not invoked during upload for non-credential RDF assets, even when `federated-catalogue.verification.schema=true`.
-The non-credential strategy does not call `SchemaValidationService` at all — credential-pipeline concepts (semantic checks, schema validation, signature verification) do not apply.
-On-demand validation against specific SHACL shapes is available via the `POST /assets/validate` endpoint.
+NOTE: SHACL schema validation is not invoked during upload for non-credential RDF assets, even when the upload-time SHACL switch is enabled.
+The non-credential strategy does not call the schema validation service at all — credential-pipeline concepts (semantic checks, schema validation, signature verification) do not apply.
+On-demand validation against specific SHACL shapes is available via the dedicated on-demand validation endpoint (see the OpenAPI specification).
 
 NOTE: Whether an RDF document enters this path depends on MIME type classification by `RdfDetector` (see <<_non_rdf_asset_upload>>) and the `FormatDetector` outcome.
 A Turtle or RDF/XML document without a Gaia-X credential structure classified as `UNKNOWN` by `FormatDetector` triggers this path.
@@ -788,8 +780,8 @@ Detection rules:
 |===
 | Content-Type | Body prefix | Result
 | JWT type (e.g., `application/vc+jwt`) | `eyJ` (JWT) | Accept as JWT
-| JWT type | Not JWT | HTTP 400 (content-type/body mismatch)
-| JSON-LD type (e.g., `application/ld+json`) | `eyJ` (JWT) | HTTP 400 (content-type/body mismatch)
+| JWT type | Not JWT | Reject — content-type/body mismatch
+| JSON-LD type (e.g., `application/ld+json`) | `eyJ` (JWT) | Reject — content-type/body mismatch
 | JSON-LD type | JSON-LD body | Accept as JSON-LD
 | Not provided | `eyJ` (JWT) | Accept as JWT (fallback detection)
 | Not provided | JSON-LD body | Accept as JSON-LD
@@ -860,9 +852,15 @@ The Graph Store is the interface for interacting with the Graph Database. It rec
 
 All consumers depend on a single `GraphStore` bean: `RoutingGraphStore` (marked `@Primary`). It delegates every method to the currently-active adapter, held behind a `volatile` reference. The admin "Switch Backend" action calls a synchronized `setActive(GraphBackendType)` method on the routing store, so subsequent reads observe the new backend immediately without a restart. Each backend adapter (Neo4j, Fuseki) opens its driver lazily on first use; this keeps the application bootable when an inactive backend is unreachable.
 
-A `GraphStoreHealthIndicator` (Spring Boot `HealthIndicator`) reports the graph store status via the `/actuator/health` endpoint. On startup, `GraphStoreStartupChecker` detects when a real backend (Neo4j or Fuseki) is active but contains no claims, and triggers an asynchronous rebuild from the metadata store via `GraphRebuildService`. Administrators can also trigger a rebuild or check its progress through the `GraphAdminController` REST endpoints (`POST /admin/graph/rebuild`, `GET /admin/graph/rebuild/status`, `GET /admin/graph/status`). After an admin backend switch, the same rebuild path repopulates the newly-active store from the metadata store.
+A health indicator reports the graph store status as part of the standard Spring Boot health endpoint.
+On startup, a startup-checker component detects when a real backend (Neo4j or Fuseki) is active but contains no claims, and triggers an asynchronous rebuild from the metadata store.
+Administrators can also trigger a rebuild or check its progress through the graph admin endpoints (see the OpenAPI specification).
+After an admin backend switch, the same rebuild path repopulates the newly-active store from the metadata store.
 
-Triggering a rebuild is **idempotent**. The rebuild re-imports claims from all active credentials into the graph via `addClaims`, which overwrites any existing claims for the same credential subject. Running a rebuild on an already up-to-date graph produces the same end state. If a rebuild is already in progress, the endpoint returns HTTP 409 (Conflict) and no second rebuild is started.
+Triggering a rebuild is **idempotent**.
+The rebuild re-imports claims from all active credentials into the graph, which overwrites any existing claims for the same credential subject.
+Running a rebuild on an already up-to-date graph produces the same end state.
+A rebuild already in progress short-circuits a subsequent rebuild request as a conflict — the OpenAPI specification is authoritative for the error contract.
 
 [source,java]
 ----
@@ -1006,7 +1004,8 @@ classDiagram
     AssetStore ..> IriValidator : uses
 ....
 
-The `AssetStore` provides two parallel access paths: **hash-based** methods (internal, used for content deduplication and file storage) and **IRI-based** methods (public API, introduced by CAT-FR-AM-02). Key IRI-based operations:
+The `AssetStore` provides two parallel access paths: **hash-based** methods (internal, used for content deduplication and file storage) and **IRI-based** methods (public API).
+Key IRI-based operations:
 
 [cols="2,3", options="header"]
 |===
@@ -1021,42 +1020,22 @@ See ADR 7, Hash-Based Mutation Operations Exception. `deleteAsset` publishes an 
 
 The `IriGenerator` assigns IRIs before storage: it extracts IRIs from RDF content (`credentialSubject.id`, `@id`, ontology/shapes/vocabulary IRIs) or generates UUID URNs (RFC 4122) for non-RDF assets and as fallback. The `IriValidator` checks all assigned IRIs against supported formats (DIDs, UUID URNs, generic URNs, HTTP/HTTPS IRIs) — returning `true`/`false`. Callers decide how to handle invalid IRIs (fallback to UUID URN, or reject the request).
 
-The asset metadata is stored in the metadata store, using the following data model:
+Asset metadata is persisted in the relational metadata store.
+Each asset row carries:
 
+* a surrogate technical identifier and a content hash (with uniqueness enforced over the hash);
+* the asset's IRI (the public identifier, see ADR 7) and the issuer;
+* lifecycle state (active / deprecated / expired / revoked / end-of-life) and the timestamps that drive it;
+* file metadata (content type, size, original filename) — these accompany every asset, including credentials, regardless of whether the bytes live in the database or in the File Store;
+* a raw-content column that is nullable: for RDF credentials it holds the JSON-LD body, for non-RDF assets the bytes live only in the File Store;
+* user-attribution columns populated by JPA auditing from the JWT subject in the security context (null for unauthenticated operations and for rows that predate the introduction of attribution).
 
-.ASSET table
-[cols="1,2,1,3", options="header"]
-|===
-| Type | Column | Key | Note
+The exact column shape, datatypes, and constraint names are defined in the Liquibase changelog (the authoritative schema reference); inspect the migration scripts in the source tree rather than restating them here.
 
-| BIGINT | id | PK | Surrogate key, generated by `assets_id_seq` sequence
-| VARCHAR(64) | asset_hash | UQ | Content hash — unique constraint (`uq_assets_asset_hash`)
-| TEXT | subjectid | |
-| TEXT | issuer | |
-| TIMESTAMP | uploadtime | |
-| TIMESTAMP | statustime | |
-| TIMESTAMP | expirationtime | |
-| SMALLINT | status | | Lifecycle status ordinal (0=ACTIVE, 1=DEPRECATED, …)
-| TEXT | content | | nullable — NULL for non-RDF assets
-| VARCHAR[] | validators | |
-| VARCHAR | content_type | | MIME type (e.g. application/pdf)
-| BIGINT | file_size | | asset size in bytes
-| VARCHAR(500) | original_filename | | client-provided filename
-| TEXT | change_comment | | optional change note for this version
-| VARCHAR(255) | created_by | | JWT subject of the user who created the record (null for pre-existing rows)
-| VARCHAR(255) | modified_by | | JWT subject of the user who last modified the record
-| TIMESTAMPTZ | created_at | | Populated by Spring Data JPA `@CreatedDate`; immutable after insert
-| TIMESTAMPTZ | last_modified_at | | Populated by Spring Data JPA `@LastModifiedDate`
-|===
+NOTE: The asset table evolved out of the original Self-Description store: a relational migration renamed the table from its Self-Description-era name to `assets` and demoted the content hash from primary key to a unique constraint, in favour of a surrogate technical identifier.
+The migration history is preserved in the Liquibase changelog and is documented for operators reading historical migrations, but the architecture only depends on the present shape.
 
-.Asset table notes
-****
-. The table was renamed from `sdfiles` to `assets` and the primary key from `sdhash` to `asset_hash` (see Liquibase changeset `2026-03-09-rename-sdfiles-to-assets`). A subsequent migration (`2026-03-25-technical-ids-assets`) introduced a surrogate `BIGINT` primary key (`id`) with a sequence, demoting `asset_hash` to a unique constraint.
-. The `content` column is nullable. For credentials (RDF), it stores the JSON-LD in the database. For non-RDF assets, content is stored only in the File Store and the database column remains `NULL`. The three asset metadata columns (`content_type`, `file_size`, `original_filename`) are backfilled with `content_type = 'application/ld+json'` for existing records.
-. The `subjectid` column stores the asset's IRI (see ADR 7) — for RDF assets this is the extracted `credentialSubject.id` or equivalent; for non-RDF assets this is a UUID URN generated by `IriGenerator`.
-. The table is audited by Hibernate Envers — all insert, update, and delete operations are tracked in the `assets_aud` shadow table (see <<_audit_history>>).
-. The `created_by` and `modified_by` columns are populated by Spring Data JPA auditing via `SecurityAuditorAware`, which reads the JWT subject from the security context. They are null for unauthenticated operations and for rows that predate CAT-FR-LM-03.
-****
+Audit-trail integration is documented under <<_audit_history,Audit History>>.
 
 [[_validation_result_storage]]
 ==== Validation Result Storage
@@ -1094,33 +1073,20 @@ classDiagram
     ValidationResultStore ..> ValidationResultGraphWriter : delegates graph write
 ....
 
-.VALIDATION_RESULT table
-[cols="1,2,1,3", options="header"]
-|===
-| Type | Column | Key | Note
+Each validation-result record carries:
 
-| BIGINT | id | PK | Surrogate key, sequence-generated (allocation size 50)
-| TEXT[] | asset_ids | | Asset subject IRI(s) — GIN indexed for efficient `= ANY()` lookups
-| TEXT[] | validator_ids | | Validator IDs (schema IRIs or trust framework IDs) used in this run
-| VARCHAR(64) | validator_type | | `SHACL`, `JSON_SCHEMA`, `XML_SCHEMA`, or `TRUST_FRAMEWORK`
-| BOOLEAN | conforms | | True if validation passed; false if violations were found
-| TIMESTAMPTZ | validated_at | | Timestamp of the validation run (caller-supplied, not DB insertion time)
-| TEXT | report | | Serialised validation report; null for passing validations
-| VARCHAR(64) | content_hash | | SHA-256 hex digest over canonical JSON of core fields — tamper detection
-| VARCHAR(16) | graph_sync_status | | `SYNCED` or `FAILED` — set atomically when the record is first stored
-| TIMESTAMPTZ | created_at | | DB insertion time, populated by Spring Data JPA `@CreatedDate`
-|===
+* the list of asset IRIs the run covered and the list of validator identifiers that produced the result;
+* the validator family (SHACL, JSON Schema, XML Schema, or trust-framework compliance);
+* a conformance flag and, on failure, the serialised validation report;
+* the validation timestamp (caller-supplied, distinguishing the validation event from the row's insertion time);
+* a content hash over the core fields to support tamper detection;
+* a graph-projection status indicating whether the row was successfully mirrored into the graph store as `fcmeta:` triples on first store.
 
-The two REST endpoints for validation result retrieval are:
+The IRI column is indexed for efficient lookup by asset identifier.
+The OpenAPI specification is authoritative for the REST endpoints (paginated retrieval per asset, and single-record retrieval by surrogate identifier).
 
-[cols="2,3", options="header"]
-|===
-| Endpoint | Description
-| `GET /assets/{id}/validations` | Paginated list of `StoredValidationResult` for the asset identified by IRI `{id}`. Returns 200 with an empty list if the asset exists but has no stored validations; 404 if the asset does not exist.
-| `GET /validations/{id}` | Single `StoredValidationResult` by its surrogate database ID. Returns 404 if not found.
-|===
-
-After a graph backend reset, `GraphRebuilder.rebuildValidationResults()` re-projects all validation result records as `fcmeta:` triples from PostgreSQL, restoring graph state without re-running verification. Each record is updated to `SYNCED` on success or `FAILED` if the graph write fails.
+After a graph backend reset, the rebuilder re-projects all validation result records as `fcmeta:` triples from the relational store, restoring graph state without re-running verification.
+Rows whose projection succeeds are marked synced; rows whose projection fails are marked accordingly for retry.
 
 **Asset deletion cascade:** When an asset is deleted, `AssetStoreImpl` publishes an `AssetDeletedEvent`.
 Two `@TransactionalEventListener(BEFORE_COMMIT)` consumers run inside the same transaction as the asset deletion:
@@ -1259,46 +1225,19 @@ public interface SchemaStore {
 }
 ----
 
-Schema versioning is implemented via Hibernate Envers (see <<_audit_history>>). Every `PUT /schemas/{id}` call triggers a JPA `save()`, causing Envers to append a snapshot to `schemafiles_aud`. The `SchemaAuditRepository` component (DAO layer) encapsulates all Envers API calls (`AuditReaderFactory`, `AuditEntity` queries), keeping Envers types out of `SchemaJpaDao`. Versions exposed through the API are 1-based positional ordinals computed over per-schema revisions in ascending order.
+Schema versioning is implemented via Hibernate Envers (see <<_audit_history>>).
+Each schema replace operation triggers a JPA save, causing Envers to append a revision snapshot to the schema audit shadow.
+The audit-repository DAO encapsulates all Envers API calls so that the persistence layer for the main schema entity remains free of Envers types.
+Versions exposed through the API are 1-based positional ordinals computed over per-schema revisions in ascending order.
 
-The schema metadata is stored in the metadata store, using the following data model:
+The schema metadata is persisted in the relational metadata store and conceptually comprises:
 
-[mermaid, width=2000]
-....
-erDiagram
-    SCHEMAFILE {
-        BIGINT id PK
-        VARCHAR schemaid UK
-        VARCHAR namehash
-        TIMESTAMP created_at
-        TIMESTAMP modified_at
-        VARCHAR created_by
-        VARCHAR modified_by
-        VARCHAR type
-        TEXT content
-    }
+* a schema-file entity carrying the schema identifier (the unique business key), the schema type (one of *ontology*, *shape*, *vocabulary*), the raw schema content, and the same audit-attribution columns as the asset entity;
+* a schema-term entity holding the set of terms (classes, properties, vocabulary entries) declared by each schema, with global uniqueness across all schema files;
+* a revalidator-chunk entity used by the background re-validation worker (see <<_re_validation>>) to checkpoint its progress.
 
-    SCHEMATERM {
-        BIGINT id PK
-        VARCHAR term
-        BIGINT schema_file_id FK
-    }
-
-    REVALIDATORCHUNK {
-        INTEGER chunkid PK
-        TIMESTAMP lastcheck
-    }
-
-    SCHEMAFILE ||--o{ SCHEMATERM : defines
-....
-
-.Schema table notes
-****
-. `schemaid` is the unique business key (natural identifier, enforced by a DB unique constraint).
-. `type` valid values: `ONTOLOGY`, `SHAPE`, `VOCABULARY`.
-. `term` is globally unique across all schema files (enforced by a DB unique constraint).
-. `SCHEMAFILE.id` uses sequence `schemafiles_id_seq`; `SCHEMATERM.id` uses `schematerms_id_seq`.
-****
+The relationships are one schema-file to many schema-terms; the chunk entity is independent.
+As before, the authoritative column shape lives in the Liquibase changelog.
 
 ==== Validator Cache
 
@@ -1346,109 +1285,42 @@ public interface ValidatorCache {
 
 ----
 
-The Validator Cache is stored in the metadata store, using the following data model:
-
-[mermaid, width=2000]
-....
-erDiagram
-    VALIDATORCACHE {
-        VARCHAR diduri
-        CLOB publickey
-        TIMESTAMP expirationtime
-    }
-
-....
+The validator cache is persisted in the relational metadata store as a single entity keyed by the validator's DID URI, holding the cached public key and the expiration timestamp at which the cache entry must be refreshed.
 
 [[_audit_history]]
 ==== Audit History (Hibernate Envers)
 
-The catalogue uses Hibernate Enversfootnote:[https://hibernate.org/orm/envers/[Hibernate Envers — Entity Auditing]] to maintain an audit trail for assets and schemas. Every insert, update, and delete on an audited entity is recorded in a corresponding `_aud` shadow table, linked to a global revision in the `REVINFO` table.
+The catalogue uses Hibernate Enversfootnote:[https://hibernate.org/orm/envers/[Hibernate Envers — Entity Auditing]] to maintain an audit trail for assets and schemas.
+Every insert, update, and delete on an audited entity is recorded in a corresponding shadow table, linked to a global revision entity that timestamps each operation.
 
-Audited entities: `Asset` (`assets`), `SchemaFile` (`schemafiles`), `SchemaTerm` (`schematerms`).
-
-[mermaid, width=2000]
+[mermaid]
 ....
 erDiagram
-    REVINFO {
-        INTEGER rev PK
-        BIGINT revtstmp
-    }
-
-    ASSETS_AUD {
-        BIGINT id PK
-        INTEGER rev FK "composite PK with id"
-        SMALLINT revtype
-        VARCHAR asset_hash
-        TEXT subjectid
-        TEXT issuer
-        TIMESTAMP uploadtime
-        TIMESTAMP statustime
-        TIMESTAMP expirationtime
-        SMALLINT status
-        TEXT content
-        VARCHAR content_type
-        BIGINT file_size
-        VARCHAR original_filename
-        TEXT change_comment
-        VARCHAR created_by
-        VARCHAR modified_by
-        TIMESTAMPTZ created_at
-        TIMESTAMPTZ last_modified_at
-    }
-
-    SCHEMAFILES_AUD {
-        BIGINT id PK
-        INTEGER rev FK "composite PK with id"
-        SMALLINT revtype
-        VARCHAR schemaid
-        VARCHAR namehash
-        TIMESTAMP created_at
-        TIMESTAMP modified_at
-        VARCHAR created_by
-        VARCHAR modified_by
-        VARCHAR type
-        TEXT content
-    }
-
-    SCHEMATERMS_AUD {
-        BIGINT id PK
-        INTEGER rev FK "composite PK with id"
-        SMALLINT revtype
-        VARCHAR term
-        BIGINT schema_file_id
-    }
-
-    REVINFO ||--o{ ASSETS_AUD : tracks
-    REVINFO ||--o{ SCHEMAFILES_AUD : tracks
-    REVINFO ||--o{ SCHEMATERMS_AUD : tracks
+    Revision ||--o{ AssetSnapshot : "tracks"
+    Revision ||--o{ SchemaSnapshot : "tracks"
+    Revision ||--o{ SchemaTermSnapshot : "tracks"
 ....
 
-.Audit table notes
-****
-. Each `_aud` table mirrors the columns of its source table plus `rev` (FK to REVINFO) and `revtype` (0=INSERT, 1=UPDATE, 2=DELETE). The composite primary key is `(id, rev)`.
-. Audit tables are managed by Liquibase (changeset `2026-03-25-envers-*`), not by Hibernate's `hbm2ddl` auto-generation.
-. The `created_by` and `modified_by` columns in `assets_aud` and `schemafiles_aud` are populated by `SecurityAuditorAware`, which reads the JWT subject from the Spring Security context. They are null for unauthenticated or background operations, and for rows that predate CAT-FR-LM-03.
-. Known limitation: bulk JPQL `DELETE` or `UPDATE` statements bypass Envers because they do not trigger JPA entity lifecycle events. All current DAO code uses entity-level operations, so this limitation does not apply in practice.
-. `REVINFO.rev` uses sequence `revinfo_seq`. `revtstmp` is a Unix epoch timestamp in milliseconds.
-. `revtype` encodes the operation: 0=INSERT, 1=UPDATE, 2=DELETE.
-****
+Audited entities are the asset, the schema file, and the schema term.
+Each shadow row mirrors its source row, plus a reference to the revision and a flag indicating whether the operation was an insert, update, or delete.
+User-attribution columns on the shadow rows are populated from the JWT subject in the security context — null for unauthenticated or background operations and for rows that predate the introduction of attribution.
+
+NOTE: Bulk JPA-Query `DELETE` or `UPDATE` statements bypass Envers because they do not trigger entity lifecycle events; the catalogue therefore restricts itself to entity-level operations for audited entities.
+The exact shadow-table schema and the migrations that introduced it are defined in the Liquibase changelog.
 
 [[_verification_profiles]]
 ==== Verification Profiles
 
-The verification pipeline has four independently configurable stages. Each stage is controlled by a dedicated configuration property:
+The verification pipeline has four independently configurable stages, each toggled by a dedicated boot-time configuration switch:
 
-[options="header",cols="2,1,3"]
-|===
-| Property | Default | Description
-| `federated-catalogue.verification.semantics` | `true` | Validate credential subject `@type` against loaded ontologies
-| `federated-catalogue.verification.schema` | `false` | Validate against SHACL shapes (composite schema)
-| `federated-catalogue.verification.vp-signature` | `false` | Verify Verifiable Presentation proof (JWS)
-| `federated-catalogue.verification.vc-signature` | `false` | Verify Verifiable Credential proof (JWS)
-| `federated-catalogue.verification.trust-framework.gaiax.enabled` | `false` | Enforce Gaia-X Trust Framework compliance (trust anchor chain)
-| `federated-catalogue.verification.trust-framework.gaiax.trust-anchor-url` | _(Gaia-X registry URL)_ | URL for the Gaia-X Trust Anchor Registry (only used when enabled)
-| `federated-catalogue.verification.signature-verifier` | `uni-res` | DID resolution strategy: `local` (resolve did:web directly) or `uni-res` (Universal Resolver)
-|===
+* **Semantic validation** — checks that the credential subject's `@type` resolves against the loaded ontologies.
+* **Schema validation** — runs the credential through the composite SHACL shape graph.
+* **Verifiable Presentation signature verification** — checks the outer-envelope JWS.
+* **Verifiable Credential signature verification** — checks each inner credential's signature.
+
+A separate trust-framework toggle controls whether Gaia-X Trust Framework compliance (trust-anchor chain validation) is enforced once signatures have been verified.
+The address of the Trust Anchor Registry that this enforcement consults is carried in the relevant bundle descriptor; a DID-resolution strategy switch selects between the bundled local resolver and a remote Universal Resolver.
+The wiki https://github.com/eclipse-xfsc/federated-catalogue/wiki/Installation-%26-Configuration-Guide[Installation & Configuration Guide] documents the exact property names, environment-variable forms, and current defaults.
 
 Two deployment profiles are pre-configured. Operators may also define custom combinations.
 
@@ -1563,7 +1435,10 @@ flowchart TB
     style EXT fill:#e3f2fd,stroke:#42a5f5
 ....
 
-NOTE: The `Schema validation enabled?` branch combines two gates. The caller's `verifySchema` request parameter selects whether SHACL runs at all; the administrative SHACL module toggle (see ADR 16) then gates that branch independently. When `verifySchema=true` and SHACL is administratively disabled, the request short-circuits with `400 Bad Request` body `module_disabled:SHACL` before reaching the SHACL composite. The same pattern applies on the on-demand validation endpoint via `AssetValidationServiceImpl`.
+NOTE: The "schema validation enabled?" branch combines two gates.
+The caller's per-request `verifySchema` flag selects whether SHACL runs at all; the administrative SHACL module toggle (see ADR 16) then gates that branch independently.
+With both gates pointing in opposite directions (caller asks for SHACL but the module is administratively disabled), the request short-circuits with a `module_disabled:SHACL` error before reaching the SHACL composite.
+The same pattern applies on the on-demand validation endpoint.
 
 ===== Docker Compose configuration
 
@@ -1581,13 +1456,13 @@ docker compose -f docker-compose.yml -f docker-compose.strict.yml --env-file dev
 [[_non_rdf_asset_upload]]
 ==== Non-RDF Asset Upload
 
-The catalogue supports uploading non-RDF content (PDFs, plain JSON, YAML, images, binary files) through the same `POST /assets` endpoint, extended to accept `multipart/form-data` and `application/octet-stream` content types.
+The catalogue supports uploading non-RDF content (PDFs, plain JSON, YAML, images, binary files) through the existing asset-upload endpoint, extended to accept multipart and opaque-byte-stream content types.
 
 ===== RDF Detection
 
 The `RdfDetector` component classifies uploaded content as RDF or non-RDF using two checks:
 
-1. **MIME type allowlist:** The content type is matched against a configurable set (`federated-catalogue.rdf.content-types`).
+1. **MIME type allowlist:** The content type is matched against the operator-configurable RDF MIME-type allowlist.
 The default allowlist includes both credential formats (JSON-LD, JWT) and non-credential RDF serializations (Turtle, N-Triples, RDF/XML).
 Non-credential RDF formats support claim extraction only — they do not enter the credential verification pipeline and SHACL schema validation is not invoked for them.
 2. **Content inspection (for `application/json` only):** A regex pattern checks whether `"@context"` appears as a JSON key with a plausible JSON-LD value (array, string, or URL). Plain JSON without `@context` is classified as non-RDF.
@@ -1616,14 +1491,15 @@ flowchart TD
 For non-RDF assets:
 
 * No verification, no graph interaction
-* Content stored in `assetFileStore` (raw bytes)
-* IRI assigned by `IriGenerator`: UUID URN (`urn:uuid:...`) per RFC 4122
-* Duplicate content rejected with HTTP 409 (Conflict), with existing IRI in the error response
+* Content stored in the asset File Store (raw bytes)
+* IRI assigned by `IriGenerator`: UUID URN per RFC 4122
+* Duplicate content is rejected with the existing IRI returned in the error response (see the OpenAPI specification for the exact error contract)
 
 [[_iri_assignment]]
 ===== IRI Assignment
 
-The `IriGenerator` component assigns an IRI to each asset before storage (CAT-FR-AM-02). The strategy depends on asset type:
+The `IriGenerator` component assigns an IRI to each asset before storage.
+The strategy depends on asset type:
 
 [options="header",cols="1,2,2"]
 |===
@@ -1648,12 +1524,14 @@ Invalid IRIs (null, blank, or syntactically malformed) are rejected before stora
 
 ===== Asset Upload Configuration
 
-[options="header",cols="2,1,3"]
-|===
-| Property | Default | Description
-| `federated-catalogue.rdf.content-types` | `[application/ld+json, application/vc+ld+json, application/vp+ld+json, application/vc+jwt, application/vp+jwt, text/turtle, application/n-triples, application/rdf+xml]` | MIME types classified as RDF by `RdfDetector`. Credential types (`vc+ld+json`, `vc+jwt`, etc.) enter the full verification pipeline. Non-credential RDF serializations (Turtle, N-Triples, RDF/XML) support claim extraction only. SHACL schema validation is not invoked at upload — even when `federated-catalogue.verification.schema=true` — because the `UNKNOWN` format path bypasses the validation step. On-demand validation is available via `POST /assets/validate`.
-| `federated-catalogue.file-store.asset.location` | _(required in production)_ | File system directory for non-RDF asset content
-|===
+Two boot-time configuration concerns are relevant to the upload pipeline:
+
+* The **RDF MIME-type allowlist** determines which content types the catalogue classifies as RDF.
+Credential MIME types (`application/vc+ld+json`, `application/vc+jwt`, and the presentation variants) enter the full verification pipeline; non-credential RDF serializations (Turtle, N-Triples, RDF/XML) enter the claim-extraction-only path.
+Operators may extend or restrict this list to match their deployment's verification capabilities.
+* The **non-RDF asset File Store location** must be configured in production deployments; the application fails to start if it is missing.
+
+Both properties are documented in the wiki configuration guide.
 
 [[_asset_link_service]]
 ==== Asset Link Service
@@ -1661,13 +1539,10 @@ Invalid IRIs (null, blank, or syntactically malformed) are rejected before stora
 The Asset Link Service manages bidirectional links between machine-readable (RDF) assets and
 human-readable representations (e.g., PDF, DOCX, HTML, plain text).
 
-Links are created via `POST /assets/{mrId}/human-readable` (201 Created; 409 Conflict if an HR
-asset is already linked) and replaced via `PUT /assets/{mrId}/human-readable` (200 OK; 404 Not
-Found if no HR asset is linked yet). Content retrieval is exposed via
-`GET /assets/{mrId}/human-readable` (returns the HR asset bytes) and
-`GET /assets/{hrId}/machine-readable` (returns the MR asset bytes). The linked asset IRI is
-surfaced in the metadata response as `humanReadableId` (on MR assets) and `machineReadableId`
-(on HR assets).
+The endpoint exposes a *create* operation (rejected if the machine-readable asset is already linked) and a *replace* operation (rejected if no human-readable asset is linked yet).
+Two content-retrieval endpoints serve the linked counterpart from either direction.
+The linked asset IRI is surfaced in each side's metadata response under fields that identify the counterpart asset.
+The OpenAPI specification is authoritative for the exact paths, request bodies, and error contracts.
 
 Accepted content types for human-readable representations:
 
@@ -1680,69 +1555,47 @@ Accepted content types for human-readable representations:
 | `text/plain` | Plain text
 |===
 
-These are the default values of `federated-catalogue.assets.human-readable-content-types`.
-The same allowlist is enforced for both `POST /assets/{mrId}/human-readable` and
-`PUT /assets/{mrId}/human-readable`.
+The allowlist is operator-configurable and is enforced for both the create and replace operations on the human-readable link endpoint.
 
-* `application/pdf` and `application/vnd.openxmlformats-officedocument.wordprocessingml.document`
-  cover the main document formats typically exchanged as human-facing attachments.
-* `text/html` supports web-renderable human-readable pages.
-* `text/plain` supports lightweight textual explanations, notes, or readme-style content.
-* Validation is strict against the configured `Content-Type` header. Unsupported types are
-  rejected with `400 Bad Request`.
-* A missing `Content-Type` is treated as `application/octet-stream`, which is not accepted by
-  default and is therefore rejected as well.
+* PDF and DOCX cover the main document formats typically exchanged as human-facing attachments.
+* HTML supports web-renderable human-readable pages.
+* Plain text supports lightweight textual explanations, notes, or readme-style content.
+* Validation is strict against the request's `Content-Type` header.
+Unsupported types are rejected.
+* A missing `Content-Type` is treated as opaque octet-stream content, which is not accepted by default and is therefore rejected as well.
 
-This restriction is intentional: the human-readable link endpoint is meant for documents that a
-person can read directly. Generic binary files can still be uploaded as regular assets, but they
-are not accepted as human-readable representations unless their MIME type is explicitly allowed.
+This restriction is intentional: the human-readable link endpoint is meant for documents that a person can read directly.
+Generic binary files can still be uploaded as regular assets, but they are not accepted as human-readable representations unless their MIME type is explicitly allowed.
 
-Link metadata is stored directly on the `assets` table via two columns added by Liquibase
-changeset `012-asset-links.xml`:
-
-[mermaid, width=2000]
-....
-erDiagram
-    ASSETS {
-        BIGINT id PK
-        VARCHAR asset_type "MACHINE_READABLE | HUMAN_READABLE"
-        BIGINT linked_asset_id FK "→ assets.id ON DELETE SET NULL"
-    }
-....
-
-.Asset link columns notes
-****
-. `asset_type VARCHAR(50)` — nullable; values: `MACHINE_READABLE`, `HUMAN_READABLE`, `GENERIC`. Identifies which variant this asset represents.
-. `linked_asset_id BIGINT` — nullable FK referencing `assets.id`. `ON DELETE SET NULL` ensures that deleting the referenced asset clears the pointer without a hard cascade.
-. Unique index `idx_assets_linked_asset_id` on `linked_asset_id` enforces a strict 1:1 relationship — each HR asset can be linked to at most one MR asset and vice versa.
-. Audited automatically by Hibernate Envers via the `assets_aud` shadow table — no separate audit columns on `assets` itself.
-****
+Link metadata is stored directly on the asset entity.
+Each asset row carries an asset-type discriminator (one of *machine-readable*, *human-readable*, or *generic*) and an optional foreign-key reference to the linked counterpart asset.
+The relationship is enforced as strictly 1:1 (each human-readable asset can be linked to at most one machine-readable asset and vice versa).
+Deletion of one side clears the pointer on the other side rather than cascade-deleting.
+Link changes are captured by the existing asset audit shadow — no separate audit columns or tables are introduced.
 
 Corresponding RDF triples (`fcmeta:hasHumanReadable`, `fcmeta:hasMachineReadable`) are written to
 the graph DB as supplementary metadata. Graph writes are non-fatal: a failure is logged but does
 not roll back the PostgreSQL transaction.
 
-**Cascade delete:** Deleting an MR asset also deletes its linked HR asset (application-level cascade
-in `AssetStoreImpl`). The `ON DELETE SET NULL` FK constraint prevents orphan pointer errors at the
-database level when the HR asset row is removed.
+**Cascade delete:** Deleting a machine-readable asset also deletes its linked human-readable counterpart (an application-level cascade in the asset store).
+The relational integrity is preserved by a foreign-key constraint that clears the pointer rather than cascade-deleting at the database level when one side is removed.
 
-**Graph rebuild:** `POST /admin/graph/rebuild` restores `fcmeta:hasHumanReadable` and
-`fcmeta:hasMachineReadable` triples from the `linked_asset_id` column in the `assets` table.
+**Graph rebuild:** Triggering an admin graph rebuild restores the `fcmeta:hasHumanReadable` and `fcmeta:hasMachineReadable` triples from the persisted link references in the metadata store.
 
 [[_admin_api]]
 ==== Admin API
 
-The Admin API exposes runtime configuration and observability endpoints for catalogue administrators. All `/admin/**` endpoints require the `ADMIN_ALL` permission (see <<_authorization>>).
+The Admin API exposes runtime configuration and observability endpoints for catalogue administrators.
+All admin endpoints require the admin permission (see <<_authorization>>).
+The OpenAPI specification is authoritative for the endpoint paths, request bodies, and error contracts; the table below identifies the services in functional terms.
 
-Five delegate services in `fc-service-server` implement the admin endpoints, each corresponding to a section of the Admin UI:
-
-[options="header",cols="1,2,2"]
+[options="header",cols="1,3"]
 |===
-| Service | Implements | Endpoints
-| `AdminDashboardService` | `AdminApiDelegate` | `GET /admin/me` (access check), `GET /admin/stats` (metrics), `GET /admin/health` (component health), `GET /admin/keycloak-url`
-| `TrustFrameworkAdminService` | `TrustFrameworkAdminApiDelegate` | List, toggle, and update trust frameworks; checks live connectivity per framework on list
-| `SchemaValidationAdminService` | `SchemaValidationAdminApiDelegate` | List schema modules (SHACL, JSON Schema, XML Schema, OWL) with toggle and schema counts; toggle each module on/off; expose the per-ontology subclass contribution to each registered base class for the OWL module. SHACL, JSON Schema, and XML Schema toggles are enforced by on-demand validation (`POST /assets/validate`) via `AssetValidationService` and return `400 module_disabled:<MODULE>` when off; in upload verification only SHACL is consulted, with the same error contract. The OWL toggle gates the runtime composite-ontology subclass walk in `CredentialVerificationStrategy.resolveBaseClass` (see ADR 16)
-| `GraphDatabaseAdminService` | `GraphDatabaseAdminApiDelegate` | `GET /admin/graph-database` returns the active backend, connection state, claim count, and a `rebuildNeeded` flag with the `rdfAssetCount` that a rebuild would re-index. `POST /admin/graph-database/switch` pre-flights the target backend via `GraphStoreProbe` (Bolt for Neo4j, HTTP for Fuseki, 3 s budget each), performs the live in-process swap via `RoutingGraphStore.setActive(...)`, and only on a successful swap persists the choice to `admin_config[graphstore.preferred.backend]` — so a failed swap cannot strand a stale preference for the next cold boot. The change is observable on the next call with no JVM restart. Unreachable targets and backends with no registered adapter are both rejected with `400 Bad Request` before any state change.
+| Service | Responsibility
+| `AdminDashboardService` | Access check, metrics, component health, and discovery of the operator-facing Keycloak Admin Console URL.
+| `TrustFrameworkAdminService` | List, toggle, and update trust frameworks; checks live connectivity per framework on list.
+| `SchemaValidationAdminService` | Lists the four schema modules (SHACL, JSON Schema, XML Schema, OWL) with toggle state and schema counts, toggles each module on or off, and exposes the per-ontology subclass-contribution map for the OWL module. The three validator toggles are enforced both on the on-demand validation path and on the credential-upload schema-validation path; the OWL toggle gates the third tier of base-class resolution (see ADR 16).
+| `GraphDatabaseAdminService` | Reports the active backend, its connection state, claim count, and whether a rebuild is needed. A switch operation pre-flights the target backend (Bolt for Neo4j, HTTP for Fuseki, with a small per-probe budget), performs the live in-process swap, and only on a successful swap persists the new preference so a failed swap cannot strand a stale preference for the next cold boot. The change is observable on the next call with no JVM restart. Unreachable targets and backends with no registered adapter are rejected before any state change.
 |===
 
 These components in `fc-service-core` read admin-controlled settings during normal catalogue operations:
@@ -1750,22 +1603,27 @@ These components in `fc-service-core` read admin-controlled settings during norm
 [options="header",cols="1,1,2"]
 |===
 | Component | Triggered by | Effect of admin configuration
-| `LoirePolicyEnforcer` | Loire envelope processing (per request, via `LoireCredentialProcessor`) | Consults `TrustFrameworkService.isEnabled("gaia-x")` to decide whether Loire-specific policies (issuer `did:web` restriction, trust-chain validation) apply at all; reads `trust_anchor_url` from the bundle's `properties` for `x5u` trust-chain validation
-| `AssetValidationServiceImpl` | On-demand asset validation (`POST /assets/validate`) | Checks module state via `SchemaModuleConfigService` for `SHACL`, `JSON_SCHEMA`, and `XML_SCHEMA`. If a module is disabled, the request is rejected with `ClientException` → `400 Bad Request`, body `module_disabled:<MODULE>` (see ADR 16).
-| `CredentialVerificationStrategy` | Credential verification | Reads SHACL and OWL module state via `SchemaModuleConfigService` (cached with `@Cacheable` — hot path). Disabling SHACL returns the same `400 module_disabled:SHACL` contract on requests with `verifySchema=true`. Disabling OWL bypasses the runtime composite-ontology subclass walk in `resolveBaseClass`; credentials whose type is only reachable through that walk fall through to `ResolvedBaseClass.UNKNOWN` and are rejected by the verification entry point with `400 Bad Request` (see ADR 16). JSON Schema and XML Schema toggles do not bite on this path today — every credential is JSON-LD or JWT-wrapped JSON-LD and routes to SHACL. The Gaia-X enabled flag is consulted via `TrustFrameworkService`.
+| `LoirePolicyEnforcer` | Loire envelope processing (per request, via `LoireCredentialProcessor`) | Consults the trust-framework service to decide whether Loire-specific policies (issuer DID-method restriction, trust-chain validation) apply at all; reads the trust-anchor URL from the active bundle's effective configuration for `x5u` trust-chain validation
+| `AssetValidationServiceImpl` | On-demand asset validation | Checks module state for SHACL, JSON Schema, and XML Schema. If a module is disabled, the request is rejected with a `module_disabled:<MODULE>` error (see ADR 16); the OpenAPI specification carries the exact error contract.
+| `CredentialVerificationStrategy` | Credential verification | Reads SHACL and OWL module state (cached on the hot path). Disabling SHACL surfaces the same `module_disabled:SHACL` contract on requests that asked for schema validation. Disabling OWL bypasses the runtime composite-ontology subclass walk; credentials whose type is only reachable through that walk are rejected at the verification entry point (see ADR 16). JSON Schema and XML Schema toggles do not bite on this path today — every credential is JSON-LD or JWT-wrapped JSON-LD and routes to SHACL.
 |===
 
-The `trust_frameworks` and `admin_config` tables that back this configuration layer are documented under <<section-concepts,Cross-cutting Concepts — Admin Configuration Persistence>>.
+The persistence shape of this configuration layer is documented under <<section-concepts,Cross-cutting Concepts — Admin Configuration Persistence>>.
 
 ===== Schema-module admin toggles
 
-The admin schema-modules page (proxied from the demo portal to `GET /admin/schema-validation` on the catalogue) lists four toggleable modules — SHACL, JSON Schema, XML Schema, OWL — and surfaces an additional read-only endpoint, `GET /admin/schema-validation/ontologies`, backed by `OntologyImpactService`.
+The admin schema-modules page lists four toggleable modules — SHACL, JSON Schema, XML Schema, OWL — and surfaces an additional read-only endpoint for the per-ontology subclass-contribution map, backed by the ontology-impact service.
 
 The four toggles fall into two semantic classes (ADR 16):
 
-* **Validators (SHACL, JSON Schema, XML Schema)** gate the corresponding validator wherever the catalogue would otherwise run it (on-demand validation, and credential verification with `verifySchema=true`). When off, the affected request returns `400 Bad Request` body `module_disabled:<MODULE>`. Stored schemas remain queryable regardless of toggle state.
+* **Validators (SHACL, JSON Schema, XML Schema)** gate the corresponding validator wherever the catalogue would otherwise run it (on-demand validation, and credential verification when the caller asks for schema validation).
+When off, the affected request is rejected with a `module_disabled:<MODULE>` error.
+Stored schemas remain queryable regardless of toggle state.
 
-* **OWL** gates the third tier of base-class resolution. When off, the runtime composite-ontology subclass walk in `CredentialVerificationStrategy.resolveBaseClass` is skipped; only the registry index and `additional_roots` (ADR 10) are consulted. Credentials whose type is only reachable through the subclass walk fall through to `ResolvedBaseClass.UNKNOWN` and are rejected by the verification entry point with `400 Bad Request`. Registry-direct types are unaffected.
+* **OWL** gates the third tier of base-class resolution.
+When off, the runtime composite-ontology subclass walk is skipped; only the registry index and the bundle's additional-roots declarations (ADR 10) are consulted.
+Credentials whose type is only reachable through the subclass walk fail base-class resolution and are rejected at the verification entry point.
+Registry-direct types are unaffected.
 
 `OntologyImpactService` parses each `ONTOLOGY`-type schema row with Jena and counts the `rdfs:subClassOf+` descendants reachable from each registered role's root URI (plus any `additional_roots`), aggregated across active trust-framework bundles. The result is a read-only map of *(ontology id, role name) → subclass count* so operators can see what the OWL toggle is gating before flipping it off.
 
@@ -1827,20 +1685,20 @@ The unified terminology mirrors the unified ingest interface; it does **not** im
 **Schema validation is a separate concept.**
 Schema validation against stored SHACL shapes is available through two independent flows, and neither is what produces a `*VerificationResult`:
 
-* **At upload time**, when `federated-catalogue.verification.schema=true` (off by default), the **credential** upload path additionally invokes `SchemaValidationService` after the VC pipeline.
-A failure aborts the upload with a verification exception — the report is surfaced through the HTTP error, not through `CredentialVerificationResult`.
-For non-credential RDF the upload path currently does not invoke `SchemaValidationService` regardless of this flag (see the NOTE under <<_non_credential_rdf_extraction>>).
-* **On demand**, `POST /assets/validate` (handled by `AssetValidationService`; see <<_on_demand_asset_validation>>) validates any stored asset — credentials, non-credential RDF, plain JSON, XML — against the applicable schemas and persists a `ValidationResult` row carrying the report and an `outdated` flag.
+* **At upload time**, when the upload-time SHACL switch is enabled (off by default), the **credential** upload path additionally invokes the schema-validation service after the VC pipeline.
+A failure aborts the upload with a verification exception — the report is surfaced through the HTTP error, not through the verification result.
+For non-credential RDF the upload path currently does not invoke schema validation regardless of this flag (see the NOTE under <<_non_credential_rdf_extraction>>).
+* **On demand**, the dedicated on-demand validation endpoint (handled by `AssetValidationService`; see <<_on_demand_asset_validation>>) validates any stored asset — credentials, non-credential RDF, plain JSON, XML — against the applicable schemas and persists a validation-result row carrying the report and an outdated flag.
 
 The two flows are orthogonal to ingest-time verification:
 
 [options="header",cols="1,2,2"]
 |===
-| Aspect | Ingest-time verification (`/assets` upload, `/verification`) | On-demand validation (`/assets/validate`)
+| Aspect | Ingest-time verification (asset upload, verification endpoint) | On-demand validation (validation endpoint)
 | Applies to | Credentials → full VC pipeline; non-credential RDF → triple extraction only | Any stored asset — credentials, non-credential RDF, plain JSON, XML
 | Owned by | `VerificationServiceImpl` → `RdfIngestionStrategy` | `AssetValidationService` → `ValidationStrategy` chain
-| Schema validation | Optional, gated by `federated-catalogue.verification.schema` (default off). When enabled it runs as part of the credential upload path; failures abort the upload via exception. Currently not wired for non-credential RDF uploads. | Always available, dispatched by asset type (SHACL / JSON Schema / XML Schema)
-| Result type | `CredentialVerificationResult` or `NonCredentialVerificationResult` (carries claims, role, validators, warnings — but not a schema report) | `ValidationResult` (persisted, with `outdated` flag and full conformance report)
+| Schema validation | Optional, gated by the operator-controlled upload-time SHACL switch (default off). When enabled it runs as part of the credential upload path; failures abort the upload via exception. Not wired for non-credential RDF uploads. | Always available, dispatched by asset type (SHACL / JSON Schema / XML Schema)
+| Result type | `CredentialVerificationResult` or `NonCredentialVerificationResult` (carries claims, role, validators, warnings — but not a schema report) | `ValidationResult` (persisted, with an outdated flag and full conformance report)
 |===
 
 So the name `NonCredentialVerificationResult` does not exclude schema validation as a concept for non-credential assets — it only says: "this is the output of the ingest path, on a payload that is not a credential, therefore the VC-specific fields are null".

--- a/federated-catalogue/src/docs/architecture/chapters/05_building_block_view.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/05_building_block_view.adoc
@@ -8,9 +8,19 @@ ifndef::imagesdir[:imagesdir: ../../images]
 
 :toc:
 
-[[section-building-block-viev]]
+[[section-building-block-view]]
+== Building Block View
 
-== Overall System overview
+This chapter is the longest in the document and is organised in three levels of zoom:
+
+* **Level 1 — Components of the Federated Catalogue.** The handful of components that an external observer can see (Catalogue, Authentication, Graph-DB, File Store, Metadata Store).
+* **Level 2 — Inside the Catalogue.** Verification pipeline, schema management, validator cache, audit history, file store, metadata store, asset upload service, link service, admin API.
+* **Level 3 — Internal abstractions and data types.** Claim model, validator interface, low-level record types.
+
+Read top-to-bottom for orientation; jump by section for reference.
+Cross-cutting concerns (trust-framework bundles, admin configuration persistence, security posture, asset content-kind taxonomy) are in <<section-concepts>>.
+
+=== Overall System overview
 
 This document describes the architecture of the Federated Catalogue, a component of the XFSC stack within the Gaia-X ecosystem.
 It originates in the Gaia-X Federation Services originally defined by the GXFS programme (2021–2024); see the glossary entry for GXFS / XFSC.
@@ -1234,7 +1244,7 @@ The schema metadata is persisted in the relational metadata store and conceptual
 
 * a schema-file entity carrying the schema identifier (the unique business key), the schema type (one of *ontology*, *shape*, *vocabulary*), the raw schema content, and the same audit-attribution columns as the asset entity;
 * a schema-term entity holding the set of terms (classes, properties, vocabulary entries) declared by each schema, with global uniqueness across all schema files;
-* a revalidator-chunk entity used by the background re-validation worker (see <<_re_validation>>) to checkpoint its progress.
+* a revalidator-chunk entity used by the background re-validation worker (see <<_revalidation_service>>) to checkpoint its progress.
 
 The relationships are one schema-file to many schema-terms; the chunk entity is independent.
 As before, the authoritative column shape lives in the Liquibase changelog.

--- a/federated-catalogue/src/docs/architecture/chapters/06_runtime_view.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/06_runtime_view.adoc
@@ -1244,8 +1244,9 @@ sequenceDiagram
 ....
 
 === Detailed sub-scenarios
-The previous section described the sce
-This section describes some sub scenarios, that occure
+
+The preceding sections described the end-to-end scenarios.
+This section zooms in on the recurring sub-scenarios that they share — internal flows that are referenced from several places above and benefit from being explained once in detail.
 
 ==== Store Credentials to the Asset Store
 This sequence diagram shows the detailed flow when storing credentials in the Asset Store.

--- a/federated-catalogue/src/docs/architecture/chapters/06_runtime_view.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/06_runtime_view.adoc
@@ -557,7 +557,9 @@ sequenceDiagram
 
 ==== Requesting a specific Asset
 
-Assets can be retrieved by their IRI. The IRI is URL-encoded in the path parameter. The optional `?version=X` query parameter retrieves a specific historical version (1-based ordinal). Without it, the current version is returned. A non-existent version number returns HTTP 404.
+Assets can be retrieved by their IRI; the IRI is URL-encoded in the path parameter.
+An optional version query parameter retrieves a specific historical version (1-based ordinal); without it, the current version is returned.
+The OpenAPI specification carries the exact endpoint contract and the error response for unknown versions.
 
 [mermaid, width=2000]
 ....
@@ -663,15 +665,19 @@ sequenceDiagram
 
 **Step 7-8:** `IriGenerator` generates a UUID URN (`urn:uuid:...`) per RFC 4122 for the non-RDF asset. Each upload receives a unique IRI.
 
-**Step 9:** `storeUnverified` persists the metadata (including the assigned IRI) in PostgreSQL. If an asset with the same content hash already exists, HTTP 409 (Conflict) is returned with the existing IRI in the error response.
+**Step 9:** `storeUnverified` persists the metadata (including the assigned IRI) in the relational metadata store.
+If an asset with the same content hash already exists, the upload is rejected as a conflict with the existing IRI returned in the error response.
 
 **Step 11:** The raw bytes are written to the `assetFileStore`, not the schema/context File Store.
 
 ==== Updating an Asset
 
-Assets are updated via `PUT /assets/{id}`. The update is applied in-place on the single row for that IRI; Hibernate Envers captures the previous state as a new revision in `assets_aud` automatically. No DEPRECATED row is created. The optional `changeComment` query parameter is recorded on the new revision.
+Assets are updated via the asset-update endpoint (see the OpenAPI specification).
+The update is applied in-place on the single row for that IRI; the audit framework captures the previous state as a new revision automatically.
+No new lifecycle row is created.
+An optional change-comment parameter is recorded on the new revision.
 
-The IRI extracted from the credential body must match the path `{id}`. If they diverge, HTTP 400 is returned.
+The IRI extracted from the credential body must match the IRI in the request path; divergence is rejected as a bad request.
 
 [mermaid, width=2000]
 ....
@@ -689,7 +695,7 @@ sequenceDiagram
     API ->> + VerificationService:verifyCredential(credential)
     VerificationService -->> - API:CredentialVerificationResult
     API ->> + AssetStore:storeCredential(AssetMetadata, CredentialVerificationResult)
-    Note right of AssetStore: In-place UPDATE - Envers records previous state in assets_aud
+    Note right of AssetStore: In-place UPDATE - audit framework records previous state in the asset audit shadow
     AssetStore -->> - API:OK
     API -->> - User:200 Asset
 ....
@@ -713,7 +719,7 @@ sequenceDiagram
     API --> API:Check[credential-participant == user-participant | Ro-MU-CA]
     alt credential.type != Participant
         API -->> User: [Error. Use Participant API]
-        Note right of User: The handling of participant credentials is still open. See #6
+        Note right of User: The handling of participant credentials is still open.
     else credential.type == Offering
         API ->> + AssetStore: changeLifeCycleStatus(assetHash, REVOKED)
         AssetStore -->> GraphDB: deleteClaims(credentialSubject)
@@ -725,7 +731,8 @@ sequenceDiagram
 
 ==== Get Asset Version History
 
-Returns the full version history for an asset, ordered newest-first. Supports pagination via `?page` and `?size` (defaults: 0 and 20). Returns HTTP 404 if the asset IRI is unknown.
+Returns the full version history for an asset, ordered newest-first, with standard page/size pagination parameters.
+The OpenAPI specification carries the exact parameter names, defaults, and error response for an unknown IRI.
 
 [mermaid, width=2000]
 ....
@@ -748,7 +755,9 @@ sequenceDiagram
 
 ==== Revoking a Specific Asset Version
 
-Revokes the current version of an asset by version ordinal. Only the current (latest) version can be revoked — attempting to revoke a historical version returns HTTP 409. After revocation the asset is unavailable via `GET /assets/{id}` (404) until a new version is uploaded.
+Revokes the current version of an asset by version ordinal.
+Only the current (latest) version can be revoked — attempting to revoke a historical version is rejected as a conflict.
+After revocation the asset is unavailable via the asset-retrieval endpoint until a new version is uploaded.
 
 [mermaid, width=2000]
 ....
@@ -941,7 +950,8 @@ sequenceDiagram
 
 ==== Get a Schema
 
-The optional `?version=X` query parameter retrieves a specific historical version. Without it, the current version is returned. A non-existent version number returns HTTP 404.
+An optional version query parameter retrieves a specific historical version; without it, the current version is returned.
+The OpenAPI specification carries the exact parameter name and the error response for unknown versions.
 
 [mermaid, width=2000]
 ....
@@ -1062,7 +1072,7 @@ sequenceDiagram
 
 * No RDF parsing, type detection, or term extraction occurs.
 * No graph database interaction — the schema is not added to the composite schema graph.
-* The identifier is content-addressable (`urn:schema:sha256:<hash>`); uploading identical content returns HTTP 409 Conflict.
+* The identifier is content-addressable (a `urn:schema:sha256:<hash>` URN); uploading identical content is rejected as a conflict.
 * The schema appears in `GET /schemas` under the `jsonSchemas` or `xmlSchemas` list.
 
 
@@ -1136,9 +1146,13 @@ When calling `GET /query` a HTML page with a query input form is displayed.
 
 ==== Query the catalogue
 
-The query endpoint uses the `Content-Type` header to select the query language: `application/opencypher-query` for openCypher (Neo4j backend) or `application/sparql-query` for SPARQL-star (Fuseki backend). The request body is raw query text (not a JSON wrapper). Queries in a language not supported by the active backend are rejected with HTTP 415 (Unsupported Media Type), including a message that names the active backend, the supported language and the expected `Content-Type`. When the graph store is disabled (`graphstore.impl=none`), queries are rejected with HTTP 503 (Service Unavailable).
+The query endpoint uses the `Content-Type` header to select the query language: `application/opencypher-query` for openCypher (Neo4j backend) or `application/sparql-query` for SPARQL-star (Fuseki backend).
+The request body is raw query text (not a JSON wrapper).
+Queries in a language not supported by the active backend are rejected with an "unsupported media type" response that names the active backend, the supported language, and the expected content-type.
+When the graph store is disabled, queries are rejected with a "service unavailable" response.
 
-Only read queries are allowed. Write queries (e.g., `CREATE`/`DELETE` in openCypher, `INSERT`/`DELETE` in SPARQL) are rejected with HTTP 500.
+Only read queries are allowed.
+Write queries (e.g., `CREATE`/`DELETE` in openCypher, `INSERT`/`DELETE` in SPARQL) are rejected.
 
 [mermaid, width=2000]
 ....
@@ -1235,7 +1249,10 @@ This section describes some sub scenarios, that occure
 
 ==== Store Credentials to the Asset Store
 This sequence diagram shows the detailed flow when storing credentials in the Asset Store.
-Each IRI maps to a single row in the metadata store. On first upload, a new row is inserted (version 1). On subsequent uploads for the same IRI, the existing row is updated in-place; Hibernate Envers captures the previous state automatically in `assets_aud`. Concurrent modifications are serialized by the database row-level lock on the UPDATE.
+Each IRI maps to a single row in the metadata store.
+On first upload, a new row is inserted (version 1).
+On subsequent uploads for the same IRI, the existing row is updated in-place; the audit framework captures the previous state automatically in the asset audit shadow.
+Concurrent modifications are serialized by the database row-level lock on the UPDATE.
 
 [mermaid, width=2000]
 ....
@@ -1250,7 +1267,7 @@ sequenceDiagram
         MetaData -->> AssetStore:existing row or NULL
         alt existing row found (update)
             AssetStore ->> MetaData:updateInPlace(fields, changeComment)
-            Note right of MetaData: Envers records previous state in assets_aud
+            Note right of MetaData: Audit framework records previous state in the asset audit shadow
             MetaData -->> AssetStore:OK
             AssetStore ->> GraphDB:deleteClaims(credentialSubject)
         else no existing row (first upload)
@@ -1332,11 +1349,11 @@ See <<_format_detection>>.
 
 **Schema validation** (when enabled) checks the uploaded credentials against a composite schema of type SHACL.
 If a credential does not conform to the composite schema, a verification exception is thrown with a message containing the validation report. In that case, the verification process does not proceed, and claims are not extracted.
-Automatic schema validation against stored SHACL shapes is **disabled by default in the upload verification flow** and is gated by `federated-catalogue.verification.schema`.
+Automatic schema validation against stored SHACL shapes is **disabled by default in the upload verification flow** and is gated by the operator-controlled upload-time SHACL switch.
 When enabled, upload verification still routes through `SchemaValidationService` (see <<_schema_validation_service>>).
 On-demand validation of stored assets — covering SHACL, JSON Schema, and XML Schema — is provided by the dedicated `AssetValidationService` (see <<_on_demand_asset_validation>>); both flows evaluate SHACL via the same TopBraid SHACL engine.
 
-NOTE: For backward compatibility, automatic schema validation during upload can be re-enabled via the configuration property `federated-catalogue.verification.schema=true`.
+NOTE: For backward compatibility, automatic schema validation during upload can be re-enabled at boot time; the property name is documented in the wiki configuration guide.
 
 **Cryptographic verification (trust verification)** (when enabled) verifies JWT signatures. The `JwtSignatureVerifier` verifies the compact JWT signature by resolving the issuer's DID document, matching the `kid` to an `assertionMethod` verification method, and verifying the JWS with nimbus-jose-jwt. Key security constraints:
 

--- a/federated-catalogue/src/docs/architecture/chapters/07_deployment_view.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/07_deployment_view.adoc
@@ -13,27 +13,40 @@ ifndef::imagesdir[:imagesdir: ../../images]
 
 == Deployment View
 
-The Federated Catalogue is provided as a container based application. The different components are shown in <<img_deployment_view>>. The main component is the `Federated Catalogue Server`. It requires a PostgreSQL-Serverfootnote:[https://www.postgresql.org/[PostgreSQL: The world's most advanced open source database]] instance to store asset metadata and a graph database instance to store the (credential) claims graph and to support the query interface of the catalogue. The graph database backend is pluggable, selected via the `graphstore.impl` configuration property. Supported backends are Neo4jfootnote:[https://neo4j.com/[Neo4j Graph Data Platform | Graph Database Management System]] (openCypher queries) and Apache Jena Fusekifootnote:[https://jena.apache.org/documentation/fuseki2/[Apache Jena Fuseki]] (SPARQL-star queries).
+The Federated Catalogue is provided as a container-based application.
+The components are shown in <<img_deployment_view>>.
+The main component is the `Federated Catalogue Server`.
+It requires a PostgreSQL-Serverfootnote:[https://www.postgresql.org/[PostgreSQL: The world's most advanced open source database]] instance to store asset metadata, and a graph database instance to store the (credential) claims graph and to support the catalogue's query interface.
+The graph database backend is pluggable.
+Supported backends are Neo4jfootnote:[https://neo4j.com/[Neo4j Graph Data Platform | Graph Database Management System]] (openCypher queries) and Apache Jena Fusekifootnote:[https://jena.apache.org/documentation/fuseki2/[Apache Jena Fuseki]] (SPARQL-star queries).
+The active backend and its connection details are operator-configurable.
 
 [#img_deployment_view,reftext='Figure {counter:refnum}']
 image::07_deployment_view.png[title="Deployment View"]
 
 In addition, a Keycloak instance is needed to handle authentication. Keycloak, as well as the portal, used to interact with the Federated Catalogue, is considered out of scope for the Federated Catalogue itself.
 
-NOTE: CAT-NFR-01footnote:[Enhancement of the XFSC Federated Catalogue. 2025. https://github.com/eclipse-xfsc/docs/blob/9a178c30f76610e5924fd72c39d259d6a8ae0461/federated-catalogue/src/docs/CAT%20Enhancement/CAT_Enhancement_Specifications%20v1.0.pdf] renamed the Keycloak role `Ro-SD-A` (Self-Description Administrator) to `Ro-AS-A` (Asset Administrator). Existing realm configurations that still reference `Ro-SD-A` should be updated to `Ro-AS-A`. The bundled `gaia-x-realm.json` already uses the new name.
+NOTE: **Configuration reference.** This chapter names the configuration switches an operator needs in order to plan a deployment, but the **authoritative list** of all Spring properties and environment variables — names, defaults, semantics — lives in the project wiki: https://github.com/eclipse-xfsc/federated-catalogue/wiki/Installation-%26-Configuration-Guide[Installation & Configuration Guide].
+Treat this chapter as a conceptual map and the wiki as the source of truth for exact names and current defaults.
 
-<<img_deployment_view>> shows the default ports for the components' interaction. The connection settings (hostnames, ports) are configurable. It is recommended to replace the default credentials. To store persistent data, the `Federated Catalogue Server`, `PostgreSQL` as well as the graph database (Neo4j or Fuseki) require a volume, which must be mounted into the container. Non-RDF assets are stored in a separate File Store directory (`federated-catalogue.file-store.asset.location`), which also requires a persistent volume in production.
+NOTE: The Keycloak role originally named `Ro-SD-A` (Self-Description Administrator) has been renamed to `Ro-AS-A` (Asset Administrator), reflecting the generalization from credentials to assets.
+Existing realm configurations that still reference the former role name should be updated; the bundled realm uses the new name.
+
+<<img_deployment_view>> shows the default ports for the components' interaction.
+The connection settings (hostnames, ports) are configurable.
+It is recommended to replace the default credentials.
+To store persistent data, the `Federated Catalogue Server`, `PostgreSQL` as well as the graph database (Neo4j or Fuseki) require a volume, which must be mounted into the container.
+Non-RDF assets are stored in a separate File Store directory, which also requires a persistent volume in production.
 
 **Trust Framework Bundle Override Directory.**
-An optional read-only directory can be mounted into the container and pointed to by the env var `FEDERATED_CATALOGUE_TRUST_FRAMEWORKS_OVERRIDE_PATH`.
-The expected layout is `<mount-point>/<bundle-id>/framework.yaml` (plus optional sibling `ontology.ttl` and `shapes.ttl` files), mirroring the classpath structure.
-Use this mount to customise bundle properties — for example to point `trust_anchor_url` or `service_url` at in-cluster targets — or to add new bundles entirely, without rebuilding the JAR.
-See ADR 10 for overlay deep-merge semantics.
+An optional read-only directory can be mounted into the container so that operators can customise bundle properties — for example to point trust-anchor or service URLs at in-cluster targets — or add new bundles entirely, without rebuilding the JAR.
+The directory layout mirrors the bundled classpath structure (one sub-directory per bundle, containing the framework descriptor and optional ontology/shapes files).
+The mount path is configured via the `FEDERATED_CATALOGUE_TRUST_FRAMEWORKS_OVERRIDE_PATH` environment variable (Spring property: `federated-catalogue.trust-frameworks.override-path`); see ADR 10 for overlay deep-merge semantics and the wiki configuration guide for the property's full description.
 
 **Activating a Trust Framework Family.**
 Bundled trust-framework families (e.g. `gaia-x`) are registered but disabled by default.
-A family can be enabled at runtime via the Admin API (persisted) or statically via the `FEDERATED_CATALOGUE_ENABLED_TRUST_FRAMEWORKS` environment variable (applied on every boot).
-Refer to the OpenAPI specification for the exact endpoint contract.
+A family can be enabled at runtime via the Admin API (persisted) or statically at start-up via the `FEDERATED_CATALOGUE_ENABLED_TRUST_FRAMEWORKS` environment variable (applied on every boot).
+Refer to the OpenAPI specification for the exact admin-endpoint contract and to the wiki configuration guide for the boot-time properties.
 
 Kubernetesfootnote:[https://kubernetes.io/[Kubernetes]] is the recommended infrastructure for production deployment. For development, Dockerfootnote:[https://www.docker.com/[Docker: Accelerated, Containerized Application Development]] in combination with docker-compose can be used.
 
@@ -41,7 +54,8 @@ Kubernetesfootnote:[https://kubernetes.io/[Kubernetes]] is the recommended infra
 
 ==== Admin Role
 
-Users need the `ADMIN_ALL` client role to access `/admin/**` endpoints. Without it, the admin UI is hidden and returns HTTP 403.
+Users need the `ADMIN_ALL` client role to access the admin endpoints.
+Without it, the admin UI is hidden and requests are rejected as unauthorised.
 
 ==== Environment Configuration
 
@@ -66,14 +80,15 @@ The user management page embeds the Keycloak Admin Console in an iFrame. Update 
 | `contentSecurityPolicy` | Add `<portal-origin>` to `frame-ancestors`
 |===
 
-Replace `<portal-origin>` with your portal URL (e.g., `http://localhost:8088` for dev, `https://catalogue.example.com` for prod). Bundled realm files already have preliminary values.
+Replace `<portal-origin>` with your portal URL.
+Bundled realm files already include preliminary values.
 
 ==== Admin Console URL
 
-The demo portal auto-derives the Admin Console URL from `keycloak.auth-server-url` and `keycloak.realm` (aliased as `admin.dashboard.keycloak-auth-server-url` / `admin.dashboard.keycloak-realm`). Override with `KEYCLOAK_ADMIN_CONSOLE_URL` (or `admin.dashboard.keycloak-admin-console-url`) if Keycloak is behind a different hostname.
+The demo portal auto-derives the Keycloak Admin Console URL from the catalogue's Keycloak server and realm settings, with an explicit override available when Keycloak is reached under a different hostname (e.g. behind an ingress).
 
 === Runtime Admin Configuration
 
-Most catalogue features that an operator can flip at runtime are persisted in the `admin_config` PostgreSQL table — including the four schema-module toggles (`schema.module.SHACL.enabled`, `schema.module.JSON_SCHEMA.enabled`, `schema.module.XML_SCHEMA.enabled`, `schema.module.OWL.enabled`) and the per-framework enabled flag in `trust_frameworks`. Values written through the admin endpoints survive restarts; no new environment variables are introduced by this layer.
-
-`federated-catalogue.verification.schema` (start-up boolean) and the four `schema.module.*.enabled` rows (admin-controlled booleans) operate at different layers. The start-up flag selects whether SHACL is consulted at all during credential upload; the admin module toggles then gate the corresponding validator wherever it would otherwise run. See ADR 16 for the toggle semantics, including the asymmetric role of the OWL toggle (which gates base-class resolution).
+Most catalogue features that an operator can flip at runtime — including the per-schema-language toggles (SHACL, JSON Schema, XML Schema, OWL) and the per-trust-framework enabled flag — are persisted by the catalogue and survive restarts.
+They do not require additional environment variables.
+The start-up SHACL configuration switch (which determines whether SHACL is consulted at all during credential upload) and the runtime module toggles operate at different layers; see ADR 16 for the toggle semantics, including the asymmetric role of the OWL toggle (which gates base-class resolution rather than a validator).

--- a/federated-catalogue/src/docs/architecture/chapters/07_deployment_view.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/07_deployment_view.adoc
@@ -50,42 +50,18 @@ Refer to the OpenAPI specification for the exact admin-endpoint contract and to 
 
 Kubernetesfootnote:[https://kubernetes.io/[Kubernetes]] is the recommended infrastructure for production deployment. For development, Dockerfootnote:[https://www.docker.com/[Docker: Accelerated, Containerized Application Development]] in combination with docker-compose can be used.
 
-=== Admin UI — Keycloak Setup
+=== Admin UI and Keycloak Integration
 
-==== Admin Role
+The catalogue's admin endpoints are gated by a dedicated client role on the Keycloak side, and the demo portal embeds the Keycloak Admin Console in an iframe for the user-management view.
+Three architectural facts shape this surface:
 
-Users need the `ADMIN_ALL` client role to access the admin endpoints.
-Without it, the admin UI is hidden and requests are rejected as unauthorised.
+* **Admin gating.** A single client role grants access to all admin endpoints; without it the admin UI is hidden and requests are rejected as unauthorised.
+* **Realms are organised per environment.** The repository ships pre-configured realm exports for development, staging, and production.
+Which realm Keycloak loads at start-up is operator-controlled.
+* **iframe embedding requires browser-security headers to be relaxed.** Both the platform realm and the catalogue realm need `X-Frame-Options` and `Content-Security-Policy` (`frame-ancestors`) adjusted to allow the portal origin; the bundled realms include preliminary values for the demo setup.
+The Admin Console URL the portal uses can be derived from the catalogue's Keycloak settings, with an explicit override available when Keycloak is reached under a different hostname (for example, behind an ingress).
 
-==== Environment Configuration
-
-Realm files are organized by environment in `keycloak/realms/{dev,staging,prod}/`. The `KC_REALM_ENV` variable selects which to load at startup.
-
-[options="header",cols="1,2"]
-|===
-| Directory | Target environment
-| `keycloak/realms/dev/` | Local development
-| `keycloak/realms/staging/` | Staging
-| `keycloak/realms/prod/` | Production
-|===
-
-==== iFrame Embedding — Security Headers
-
-The user management page embeds the Keycloak Admin Console in an iFrame. Update these headers in **both `master` and `gaia-x` realms** (via Realm Settings → Security Defenses, or in the realm JSON):
-
-[options="header",cols="1,2"]
-|===
-| Header | Change
-| `xFrameOptions` | Remove (set to empty string `""`)
-| `contentSecurityPolicy` | Add `<portal-origin>` to `frame-ancestors`
-|===
-
-Replace `<portal-origin>` with your portal URL.
-Bundled realm files already include preliminary values.
-
-==== Admin Console URL
-
-The demo portal auto-derives the Keycloak Admin Console URL from the catalogue's Keycloak server and realm settings, with an explicit override available when Keycloak is reached under a different hostname (e.g. behind an ingress).
+Step-by-step operator procedures for realm bootstrap, role assignment, iframe header changes, and the Admin Console URL override live in the wiki https://github.com/eclipse-xfsc/federated-catalogue/wiki/FC-Administration-Guide[FC Administration Guide].
 
 === Runtime Admin Configuration
 

--- a/federated-catalogue/src/docs/architecture/chapters/08_concepts.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/08_concepts.adoc
@@ -11,6 +11,8 @@ ifndef::imagesdir[:imagesdir: ../../images]
 [[section-concepts]]
 == Cross-cutting Concepts
 
+This chapter collects the concerns that cut across the components introduced in <<section-building-block-view>>: how persistent data is backed up, how the catalogue logs, how trust frameworks are packaged and overlaid, how admin configuration is persisted, the admin-API mutation conventions, the input-parsing security posture, and the asset content-kind / type taxonomy that drives metadata enrichment.
+
 === Backup
 Backing up a running application is a basic administrative operation. The recommended runtime environment for the federated catalogue is Kubernetes. See the previous section for more information. Therefore, to back up the federated catalogue, well known tools can be used.
 

--- a/federated-catalogue/src/docs/architecture/chapters/08_concepts.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/08_concepts.adoc
@@ -18,7 +18,7 @@ Data is persisted in the following components:
 
 * Federated Catalogue Server: Asset and Schema files (Filesystem)
 * Metadata Store: Asset and Schema metadata (PostgreSQL)
-* Graph store: Claims graph (Neo4j or Fuseki, depending on `graphstore.impl` configuration)
+* Graph store: Claims graph (Neo4j or Fuseki, depending on the configured backend)
 
 During the deployment it must be ensured that volumes are mounted to store the persistent data in the mentioned components.
 
@@ -79,21 +79,12 @@ Document the mapping inline with a pointer to what would un-block dropping it (t
 ==== Deploying Bundle Overlays
 
 A bundle overlay lets operators customise an existing bundle or add a new one at deployment time, without rebuilding the JAR.
-Set `FEDERATED_CATALOGUE_TRUST_FRAMEWORKS_OVERRIDE_PATH` (Spring property: `federated-catalogue.trust-frameworks.override-path`) to a directory mounted read-only into the container.
-The loader expects the layout `<override-path>/<bundle-id>/framework.yaml` (same as the classpath layout), with optional sibling `ontology.ttl` and `shapes.ttl` files.
+The operator points the catalogue at a read-only directory mounted into the container; its layout mirrors the classpath bundle layout (one sub-directory per bundle, containing the framework descriptor and optional ontology and shapes files).
 
-When the `id` in a filesystem `framework.yaml` matches a classpath bundle, the file is treated as an overlay: it only needs to declare `id` plus the fields to change.
-Nested maps merge recursively (filesystem wins per leaf key); lists and scalars replace wholesale when the overlay supplies them; sibling TTL files are inherited from the classpath bundle when the overlay directory omits them.
-A filesystem entry whose `id` has no classpath match is loaded as a brand-new bundle and must declare all mandatory fields.
-See ADR 10 for the full deep-merge rules.
-
-.Minimal overlay example — override the Trust Anchor URL for the Gaia-X compliance bundle
-[source,yaml]
-----
-id: gaia-x-2511
-properties:
-  trust_anchor_url: "https://did-server/api/trustAnchor/chain/file"
-----
+When the bundle identifier in a filesystem descriptor matches a classpath bundle, the file is treated as an overlay and only needs to declare the identifier plus the fields to change.
+Nested maps merge recursively (filesystem wins per leaf key); lists and scalars replace wholesale when the overlay supplies them; sibling ontology and shapes files are inherited from the classpath bundle when the overlay directory omits them.
+A filesystem entry whose identifier has no classpath match is loaded as a brand-new bundle and must declare all mandatory fields.
+See ADR 10 for the full deep-merge rules and the operator guide for the exact configuration surface.
 
 ==== Runtime Override Precedence
 
@@ -126,50 +117,24 @@ Gating base-class resolution is the most visible effect a toggle on a type-vocab
 [[_gxdch_loire_v2_compliance_service]]
 ==== Gaia-X Loire v2 Compliance Service
 
-The shipped Gaia-X compliance bundle (currently `gaia-x-2511`, release-tagged) wires the generic `JwtVcComplianceClient` (client type `jwt-vc-compliance`) to the canonical GXDCH HAProxy endpoint:
-
-[source,yaml]
-----
-properties:
-  client_type: jwt-vc-compliance
-  api_version: "v2"
-  service_url: "https://compliance.gaia-x.eu/v2"
-  compliance_path: "/api/credential-offers/standard-compliance"
-  timeout_seconds: 30
-----
-
-The client implementation is wire-shape-specific (POST a VP JWT, expect a VC JWT) but path-agnostic; the endpoint path is declared per bundle.
-This keeps the Gaia-X Loire / GXDCH endpoint as the reference deployment while allowing any future framework that adopts the same exchange to onboard as a new bundle, no new Java code required.
+The shipped Gaia-X compliance bundle wires a generic JWT-VC compliance client to the canonical GXDCH front-end.
+The client implementation is wire-shape-specific (it POSTs a Verifiable Presentation JWT and expects a Verifiable Credential JWT in response) but path-agnostic; the endpoint URL and request path are declared per bundle.
+This keeps the Gaia-X Loire / GXDCH endpoint as the reference deployment while allowing any future framework that adopts the same exchange to onboard as a new bundle, with no new Java code required.
 See ADR 12 for the wire-shape-in-bundle rationale.
 
-`https://compliance.gaia-x.eu/v2` is a HAProxy front-end that load-balances across the certified GXDCH operators.
-No per-operator configuration is required; the HAProxy URL is the single canonical address for Loire v2 compliance checks.
+The catalogue talks to the canonical Gaia-X compliance endpoint, which is a single URL maintained by the Gaia-X Digital Clearing House (GXDCH).
+How that endpoint distributes traffic across certified GXDCH operators is a concern of the GXDCH infrastructure itself (see the `loadbalancer/` configuration in the upstream https://gitlab.com/gaia-x/lab/gxdch[GXDCH repository]) and is intentionally out of scope here; from the catalogue's perspective there is one URL, carried in the bundle descriptor, and no per-operator configuration.
 
-**Request / response shape.**
-The catalogue POSTs a Loire-conformant Verifiable Presentation JWT to the configured `compliance_path` (in the Gaia-X bundle: `/api/credential-offers/standard-compliance`) appended to `service_url`, with a `vcid` query parameter carrying the VP JWT's `id` claim.
+**Request / response shape.** The catalogue POSTs a Loire-conformant Verifiable Presentation JWT to the configured compliance path appended to the service URL, carrying the VP JWT's `id` claim as a query parameter.
 The endpoint validates the VP against Loire 2511 criteria and returns a Compliance VC JWT signed by the selected operator.
 No authentication header is required — the GXDCH endpoint is publicly accessible.
+The OpenAPI specification of the compliance service is authoritative for the exact request and response shape.
 
-.Sketch of the exchange (non-normative; see `JwtVcComplianceClient` for the authoritative wire shape)
-[source,http]
-----
-POST https://compliance.gaia-x.eu/v2/api/credential-offers/standard-compliance?vcid=<asset-id-from-vp-jwt-id-claim>
-Content-Type: text/plain
-
-<Loire-conformant VP JWT as the raw request body>
-
-HTTP/1.1 201 Created
-Content-Type: text/plain
-
-<Compliance VC JWT as the raw response body>
-----
-
-The returned Compliance VC JWT is persisted as-is in `IssuedAttestation.rawCredential`.
+The returned Compliance VC JWT is persisted as-is alongside the asset.
 See ADR 17 for the storage rationale.
 
-**Test coverage.**
-Live GXDCH coverage requires a deployment stage whose signing certificate is reachable via a public `x5u` URL (the Trust Anchor Registry must be able to resolve the chain).
-BDD scenarios tagged `@uses.live-gxdch` are excluded from default CI; they run only in a dedicated Behave profile (`behave --tags=uses.live-gxdch`) against a QA stage with a resolvable certificate chain.
+**Test coverage.** Live GXDCH coverage requires a deployment stage whose signing certificate is reachable via a public `x5u` URL (the Trust Anchor Registry must be able to resolve the chain).
+The integration-test suite includes BDD scenarios that exercise the live path; they are excluded from default CI and run only against a QA stage with a resolvable certificate chain.
 
 === Admin Configuration Persistence
 
@@ -210,9 +175,9 @@ User-supplied content (assets, schemas, IRIs) is parsed only by hardened, sandbo
 [options="header",cols="1,2,2"]
 |===
 | Threat | Mitigation | Component
-| XXE / external DTD | `FEATURE_SECURE_PROCESSING` enabled; `ACCESS_EXTERNAL_DTD` and `ACCESS_EXTERNAL_SCHEMA` set to empty. | `XmlSchemaValidationStrategy`, XML parsers
-| SSRF via JSON `$ref` | `$ref` URI scheme allowlist: `https://` permitted; `file://`, `http://`, `ftp://`, `gopher://` rejected before schema load. | `JsonSchemaValidationStrategy`
-| SPARQL injection | IRIs validated by `requireSafeIri` before string-interpolation into SPARQL queries. | `SparqlGraphStore`
+| XXE / external DTD | JAXP secure-processing enabled; external-DTD and external-schema access disabled. | XML schema validator, XML parsers
+| SSRF via JSON `$ref` | `$ref` URI scheme allowlist: only `https://` is loaded; `file://`, `http://`, `ftp://`, and similar are rejected before schema load. | JSON schema validator
+| SPARQL injection | IRIs validated against a strict syntax check before string-interpolation into SPARQL queries. | SPARQL graph store
 |===
 
 Any new validator or store that accepts user-provided content must adopt the same posture. Hardening is enforced by tests: every new parser has at least one security-path test (malicious DTD, external `$ref`, unsafe IRI) alongside its happy-path tests.
@@ -241,16 +206,16 @@ NOTE: Enrichment eligibility is decided by `content_kind = NON_RDF` and `AssetTy
 The `MACHINE_READABLE` constraint means the payload is parseable (structured non-RDF or RDF); enrichment specifically attaches *graph-queryable* RDF claims on top of a payload that was not RDF at upload time, regardless of whether the payload was otherwise structured.
 
 **Metadata enrichment** is the process of attaching graph-queryable RDF triples to a non-RDF asset.
-An RDF payload is uploaded via `POST /assets` whose subject IRI matches an existing non-RDF asset.
+An RDF payload is uploaded against the IRI of an existing non-RDF asset.
 The service:
 
-. Parses the payload and requires at least one triple whose subject is the asset's IRI (otherwise HTTP 400).
-. Filters protected-namespace triples via `ProtectedNamespaceFilter`.
-. Replaces the asset's existing graph triples (`GraphStore.deleteClaims` → `addClaims`).
-. Persists the raw RDF payload to the `content` column on the **same `assets` row** as the non-RDF asset (`AssetStore.saveEnrichedContent`) — no new entity is created and no separate enrichment table is involved.
-Hibernate Envers records the prior state as a new revision in `assets_aud` with `changeComment = "Metadata enriched"`, so the version history of the asset includes each enrichment.
-Because the enrichment RDF lives on the asset row itself, the graph can be rebuilt from PostgreSQL at any time.
-. Returns HTTP 200; no new asset is created.
+. Parses the payload and requires at least one triple whose subject is the asset's IRI.
+. Filters out triples in protected namespaces.
+. Replaces the asset's existing graph triples.
+. Persists the raw RDF payload alongside the existing non-RDF asset (no new entity is created and no separate enrichment table is involved).
+The audit trail records each enrichment as a new revision, so the version history of the asset includes every enrichment, and the graph can be rebuilt from the relational store at any time.
 
-`HUMAN_READABLE` assets reject enrichment with HTTP 422. If the graph backend is disabled (`graphstore.impl=none`), enrichment fails with HTTP 503 — graph writes are mandatory for this path.
-The `content_kind` is **not changed** by enrichment, and each enrichment upload replaces the previous metadata entirely (overwrite semantics — no merge).
+`HUMAN_READABLE` assets reject enrichment.
+When the graph backend is disabled, enrichment is rejected as well — graph writes are mandatory for this path.
+The asset's content kind is not changed by enrichment, and each enrichment upload replaces the previous metadata entirely (overwrite semantics — no merge).
+The OpenAPI specification is authoritative for the exact HTTP status codes returned in each case.

--- a/federated-catalogue/src/docs/architecture/chapters/09_architecture_decisions.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/09_architecture_decisions.adoc
@@ -11,6 +11,13 @@ ifndef::imagesdir[:imagesdir: ../../images]
 [[section-design-decisions]]
 == Architecture Decisions
 
+This chapter records the architecture decisions that shape the Federated Catalogue, in chronological order of the decision itself rather than in dependency order.
+Each ADR captures the context, the options considered, the decision taken, and its rationale.
+ADRs may reference each other (and are sometimes superseded by later ones); the chapter is meant to be browsed by topic, not necessarily read linearly.
+
+NOTE: ADR numbers 11 through 14 are intentionally absent: they were drafted as exploratory options for the bundle/profile design but were superseded by ADR 10 (Trust Framework Bundles) before being recorded as decisions.
+The numbering gap is preserved to keep stable references to the surviving ADRs (10, 15, …) intact.
+
 === ADR 1: Monolithic vs. Microservices
 **Context:** Are the subcomponents implemented as separate micro-services or are they integrated into a single service.
 

--- a/federated-catalogue/src/docs/architecture/chapters/09_architecture_decisions.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/09_architecture_decisions.adoc
@@ -18,7 +18,8 @@ ifndef::imagesdir[:imagesdir: ../../images]
 2. **Single Service**: Easier maintainability, understanding, easier to handle concurrency (especially conflicting operations like adding an asset and changing schema)
 
 **Decision:** Implement catalogue as a modular, single service. It's easier to integrate the different components. Most components are called by only one other component. A distributed microservice implementation only introduces additional communication overhead. Scalability issues are not expected, since the main load is read-only and time consuming operations are queries against the graph db, which is a separate component that can be horizontally scaled.
-Therefore, the Federated Catalogue is considered as microservice application within the GXFS ecosystem. The federated catalogue itself also consists of different, individually deployable components.
+Therefore, the Federated Catalogue is considered as a microservice application within the surrounding Federation Services ecosystem.
+The federated catalogue itself also consists of different, individually deployable components.
 
 === ADR 2: Intra Catalogue communication
 **Context:** If the catalogue is implemented as one component, the subcomponents can communication using Method-calls. Another option is to implement an internal event-/notification system, whereby each component registers itself as a listener on other components or a central message bus.
@@ -49,14 +50,17 @@ This makes signature verification without trust anchor enforcement ineffective a
 | `gaiax.enabled` | `false` | `true`
 |===
 
-This aligns with CAT-FR-SF-04 (remove forced validation): validation flags that provide no security value without the trust framework should not be forced by default. Production deployments must explicitly enable signatures together with the trust framework.
+This aligns with the principle that validation flags providing no security value without the trust framework should not be forced by default.
+Production deployments must explicitly enable signatures together with the trust framework.
 
 === ADR 4: Non-RDF Asset Storage Strategy
 
 **Context:** The catalogue needs to support non-RDF assets (PDFs, plain JSON, YAML, images, binary files) alongside RDF credentials. Several approaches were considered:
 
 1. **Separate `/assets` endpoint and storage:** New endpoint, new database table, new service layer. Clean separation but duplicates lifecycle management, filtering, and metadata handling.
-2. **Unified endpoint with dual-path routing:** Extend the existing `POST /assets` endpoint (formerly `POST /self-descriptions`) to accept non-RDF content. Reuse the `assets` table (formerly `sdfiles`, extended with asset metadata columns), the `AssetStore` interface, and the existing filter/lifecycle infrastructure. Route to verification or direct storage based on content-type detection.
+2. **Unified endpoint with dual-path routing:** Extend the existing asset-upload endpoint (which historically served only credentials, under the Self-Description name) to also accept non-RDF content.
+Reuse the relational asset entity, the `AssetStore` interface, and the existing filter/lifecycle infrastructure.
+Route to verification or direct storage based on content-type detection.
 3. **External object storage (S3/MinIO):** Delegate non-RDF storage to an external system. Adds infrastructure complexity and a new dependency.
 
 **Decision:** Option 2 — unified endpoint with dual-path routing.
@@ -97,7 +101,8 @@ Backward compatibility is maintained by converting the legacy roles (Ro-MU-CA, R
 
 === ADR 6: Claim Class Naming Convention
 
-**Context:** CAT-NFR-01footnote:cat-enhancement[Enhancement of the XFSC Federated Catalogue. 2025. https://github.com/eclipse-xfsc/docs/blob/9a178c30f76610e5924fd72c39d259d6a8ae0461/federated-catalogue/src/docs/CAT%20Enhancement/CAT_Enhancement_Specifications%20v1.0.pdf] renamed the legacy `SdClaim` class (tied to Self-Description terminology). The team needed to decide on the new name. Three options were considered:
+**Context:** The generalisation away from Self-Description-specific terminology required renaming the legacy `SdClaim` class.
+Three options were considered:
 
 1. **`Claim`** — generic, forward-looking, but too broad for the current implementation which only extracts claims from credentials.
 2. **`AssetClaim`** — aligns with the generic asset terminology but is misleading because non-RDF assets cannot have claims.
@@ -149,10 +154,13 @@ The rename to `RdfClaim` was doen while adding non-credential claims extraction.
 
 === ADR 7: IRI-Based Asset Identification
 
-**Context:** CAT-FR-AM-02: Each Asset MUST be identified by an IRI. DIDs and UUIDs as URNs (RFC 4122) MUST be supported.footnote:cat-enhancement[] The previous implementation used content-hash-based identifiers (`urn:asset:sha256:<hash>`) for non-RDF assets and `credentialSubject` for RDF credentials. Three approaches were considered:
+**Context:** The catalogue specification requires every asset to be identified by an IRI, with explicit support for DIDs and for UUIDs in URN form.
+The previous implementation used content-hash-based identifiers for non-RDF assets and `credentialSubject` IRIs for RDF credentials.
+Three approaches were considered:
 
-1. **Keep hash-based identifiers:** Simple but violates CAT-FR-AM-02 — content hashes are not IRIs in the W3C sense, and they couple identity to content (any content change produces a new identifier).
-2. **UUID URNs for all assets:** Assign a UUID URN (`urn:uuid:...`) per RFC 4122footnote:[https://www.rfc-editor.org/rfc/rfc4122[RFC 4122 — A Universally Unique IDentifier (UUID) URN Namespace]] to every asset regardless of type. Simple and uniform but discards the meaningful identifiers already present in RDF content (DIDs, ontology IRIs).
+1. **Keep hash-based identifiers:** Simple but does not satisfy the IRI requirement — content hashes are not IRIs in the W3C sense, and they couple identity to content (any content change produces a new identifier).
+2. **UUID URNs for all assets:** Assign a UUID URN per RFC 4122footnote:[https://www.rfc-editor.org/rfc/rfc4122[RFC 4122 — A Universally Unique IDentifier (UUID) URN Namespace]] to every asset regardless of type.
+Simple and uniform but discards the meaningful identifiers already present in RDF content (DIDs, ontology IRIs).
 3. **IRI extraction with UUID fallback:** Extract IRIs from RDF content where possible (`credentialSubject.id`, `@id`, ontology/shapes/vocabulary IRIs), generate UUID URNs for non-RDF assets and as fallback for RDF content without an extractable IRI.
 
 **Decision:** Option 3 — IRI extraction with UUID URN fallback.
@@ -166,7 +174,9 @@ The public API is extended with IRI-based methods (`getById`, `getFileById`) alo
 
 The `federated-catalogue.asset.subject-id-prefix` configuration property is removed — IRI generation is now handled entirely by `IriGenerator`.
 
-**Rationale:** Extracting meaningful IRIs from RDF content preserves semantic identity (a DID or ontology IRI carries provenance information that a UUID does not). UUID URNs for non-RDF assets satisfy RFC 4122 and CAT-FR-AM-02 while providing unique, stable identifiers without coupling identity to content. The content hash is retained internally for deduplication and file storage but is no longer the public identifier.
+**Rationale:** Extracting meaningful IRIs from RDF content preserves semantic identity (a DID or ontology IRI carries provenance information that a UUID does not).
+UUID URNs for non-RDF assets satisfy RFC 4122 and the IRI requirement while providing unique, stable identifiers without coupling identity to content.
+The content hash is retained internally for deduplication and file storage but is no longer the public identifier.
 
 ==== Hash-Based Mutation Operations Exception
 
@@ -181,7 +191,10 @@ The same rationale applies to both operations:
 
 2. **Mutation semantics** Delete and revoke are irreversible operations that demand unambiguous single-row targeting. The `asset_hash` column is the PRIMARY KEY — it guarantees exactly one row is affected. The IRI identifies a _logical asset_; the hash identifies a _specific content artifact_. Mutations operate at the physical artifact level, not the logical level. For revoke specifically, hash-based lookup finds the asset regardless of its current status, enabling the business logic to return a proper 409 Conflict (e.g., attempting to revoke an already deprecated asset) rather than a misleading 404.
 
-3. **Versioning readiness (CAT-FR-LM-01)footnote:cat-enhancement[]** The planned version control feature will introduce multiple version rows per `subjectid`, each with a different `asset_hash` and status. IRI-based mutation would become increasingly ambiguous — which version should be affected? Hash-based targeting remains precise regardless of how many versions exist. When versioning is introduced, both endpoints will be replaced by version-specific operations (`POST /assets/{id}/versions/{v}/revoke`).
+3. **Versioning readiness.** The planned version-control feature will introduce multiple version rows per logical asset identifier, each with a different content hash and status.
+IRI-based mutation would become increasingly ambiguous — which version should be affected?
+Hash-based targeting remains precise regardless of how many versions exist.
+When versioning is introduced, both endpoints will be replaced by version-specific operations defined in the OpenAPI specification.
 
 4. **Audit versioning forward-look** When audit history tracking is introduced (e.g., Hibernate Envers), physical deletion conflicts with audit trail immutability. At that point, the delete operation should transition to a lifecycle status change (e.g., → EOL) rather than physical row removal. Retaining hash-based targeting keeps the migration path clean: `DELETE WHERE hash` transitions to `UPDATE status WHERE hash`. The targeting mechanism (hash) stays consistent across this evolution.
 
@@ -532,23 +545,23 @@ Adds a new endpoint and a new service path.
 2. **Unified `POST /assets` with subject-IRI routing:** reuse the existing upload endpoint; when the uploaded RDF's primary `@id` matches an existing non-RDF asset, route to the enrichment path.
 No new endpoint required.
 
-**Decision:** Option 2 — subject-IRI routing at `POST /assets`.
+**Decision:** Option 2 — subject-IRI routing at the asset-upload endpoint.
 
 * When uploaded RDF is detected and the asset store reports an existing non-RDF asset for the payload's primary subject IRI, the request is routed to the enrichment path.
-The lookup also enforces that `HUMAN_READABLE` assets cannot be enriched — they are rejected with HTTP 422.
-* The enrichment path validates that the payload contains at least one triple whose subject is the asset's IRI, filters protected-namespace triples (`ProtectedNamespaceFilter`), replaces the asset's graph triples (`deleteClaims` → `addClaims`), and persists the raw RDF to `assets.content`.
-The change is captured in the Hibernate Envers audit trail with `changeComment = "Metadata enriched"`.
-Returns HTTP 200.
+The lookup also enforces that human-readable-tagged assets cannot be enriched.
+* The enrichment path validates that the payload contains at least one triple whose subject is the asset's IRI, filters protected-namespace triples, replaces the asset's graph triples, and persists the raw RDF as new content on the existing asset row.
+The change is captured by the asset audit framework with an enrichment-specific change comment.
 * Each enrichment upload fully replaces the previous metadata (overwrite, no merge).
 This matches the existing RDF version-update semantics.
-* The `content_kind` column is never changed by enrichment.
+* The asset's content-kind discriminator is never changed by enrichment.
 It always records the original upload modality.
-* Storing the enrichment RDF in `assets.content` means the existing PostgreSQL→graph rebuild process picks up enriched non-RDF assets automatically — no extra rebuild logic needed.
+* Storing the enrichment RDF on the existing asset row means the existing relational-to-graph rebuild process picks up enriched non-RDF assets automatically — no extra rebuild logic needed.
 * Enrichment requires an active graph backend.
-If `graphstore.impl=none`, the request fails with HTTP 503 before any state change — graph writes are mandatory for this path.
+If the graph backend is disabled, the request is rejected before any state change — graph writes are mandatory for this path.
+The OpenAPI specification is authoritative for the exact error contracts.
 
 **Rationale:** Reusing the existing endpoint avoids a new API surface and keeps the upload contract consistent.
-Routing on `content_kind` is unambiguous and preserves backward compatibility — uploads for RDF assets and non-RDF assets are unaffected.
+Routing on the content-kind discriminator is unambiguous and preserves backward compatibility — uploads for RDF assets and non-RDF assets are unaffected.
 Overwrite semantics simplify the data model: no partial-merge conflicts, no ordering dependencies between enrichment uploads.
 
 **Related:** ADR 4, ADR 7.
@@ -637,16 +650,19 @@ No changes to `IssuedAttestation`, no schema migration, and no changes to any ex
 
 **Context:** The catalogue supports three graph-store backends (Neo4j, Fuseki, no-op) behind a common `GraphStore` interface. Operators need to change the active backend at runtime — for example, to move from Neo4j to Fuseki without scheduling a maintenance window — and the choice must survive a restart. A purely configuration-driven model (one adapter wired per profile, change requires editing config and restarting) makes the switch operator-hostile and couples the change to deployment tooling. Wiring all adapters and selecting one at request time keeps the switch self-service, but the choice must still be persistent and the system must not become unbootable if the operator picks a backend that is currently unreachable.
 
-**Decision:** All three adapters are wired unconditionally at boot. A single `RoutingGraphStore` (`@Primary`) holds the currently-active adapter behind a `volatile` reference and delegates every `GraphStore` call to it. Switching is exposed as `POST /admin/graph-database/switch`:
+**Decision:** All three adapters are wired unconditionally at boot.
+A single primary routing store holds the currently-active adapter behind a volatile reference and delegates every graph-store call to it.
+Switching is exposed as a dedicated admin endpoint (see the OpenAPI specification for the exact contract):
 
-. The target backend is pre-flighted by `GraphStoreProbe` — a Bolt `verifyConnectivity()` against `graphstore.neo4j.uri` for Neo4j, an HTTP GET against `graphstore.fuseki.uri` for Fuseki.
-Each probe is capped at a 3 s budget (driver-side for Bolt, request-side for HTTP), so a black-holed host cannot stall the admin endpoint past the operator's attention span.
-An unreachable target is rejected with `400 Bad Request` and no state changes.
-If the requested backend has no registered adapter in the deployment, the endpoint also returns `400` — silent fallback to `NONE` would leave the operator believing the switch succeeded.
-. On a successful probe, `RoutingGraphStore.setActive(...)` (synchronized) updates the volatile reference first; only after the swap returns is the choice persisted to `admin_config[graphstore.preferred.backend]`.
+. The target backend is pre-flighted (a Bolt connectivity check for Neo4j, an HTTP GET for Fuseki).
+Each probe is capped at a small time budget so a black-holed host cannot stall the admin endpoint past the operator's attention span.
+An unreachable target is rejected with no state changes.
+If the requested backend has no registered adapter in the deployment, the request is rejected for the same reason — silent fallback to the no-op backend would leave the operator believing the switch succeeded.
+. On a successful probe, the routing store atomically swaps the volatile reference first; only after the swap returns is the new preference persisted.
 Reversing this order would let a swap failure strand a preference for a backend the next cold boot could not actually serve.
 
-On cold boot the active backend is resolved as: persisted preference → `graphstore.impl` property → `NONE`. Each adapter opens its driver lazily on first use, so an unreachable inactive backend does not block startup.
+On cold boot the active backend is resolved as: persisted preference → deployment-time bootstrap configuration → no-op fallback.
+Each adapter opens its driver lazily on first use, so an unreachable inactive backend does not block startup.
 
 The runtime status endpoint (`GET /admin/graph-database`) reports the active backend, connectivity, claim count, and a `rebuildNeeded` flag with `rdfAssetCount`. The flag is true when the active store holds no claims but active RDF assets exist in storage — the typical state after a backend switch — and points the operator to the existing `POST /admin/graph/rebuild` endpoint, which repopulates the active backend from the metadata store.
 

--- a/federated-catalogue/src/docs/architecture/chapters/10_quality_requirements.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/10_quality_requirements.adoc
@@ -10,6 +10,14 @@ ifndef::imagesdir[:imagesdir: ../../images]
 
 [[section-quality-scenarios]]
 == Quality Requirements
-There is no additional description of the quality requirements, since there are specific quality scenarios in the specification document.
 
-The main quality requirements are scalability and maintainability.
+The detailed quality scenarios (performance targets, availability budgets, security posture, conformance criteria) are owned by the Software Requirements Specification and the successor "XFSC Federated Catalogue Enhancement" document; this chapter does not restate them.
+
+At the architectural level, two quality attributes drive the dominant trade-offs in the design:
+
+* **Scalability.** Read paths must scale horizontally (the graph store is a separate, replicable component; the catalogue itself is stateless behind its persistence layer).
+Write paths are serialised through the metadata store so consistency is enforced in one place.
+* **Maintainability.** The catalogue is a long-lived federation service.
+Decisions favour replaceability over coupling: pluggable graph backends (ADR 18), self-contained trust-framework bundles (ADR 10), and a wire-shape-agnostic compliance client (ADR 12 / ADR 17) all exist to let pieces of the system evolve independently.
+
+The remaining quality attributes (security, reliability, observability) are addressed by the cross-cutting concepts in chapter <<section-concepts>> and the relevant ADRs in chapter <<section-design-decisions>>.

--- a/federated-catalogue/src/docs/architecture/chapters/12_glossary.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/12_glossary.adoc
@@ -15,6 +15,9 @@ ifndef::imagesdir[:imagesdir: ../../images]
 |===
 |Term |Definition
 
+|GXFS (Gaia-X Federation Services)
+|A 2021–2024 funded programme (https://gxfs.eu/) that produced the original reference implementations of the Gaia-X Federation Services, including this Federated Catalogue. GXFS was a national initiative under the umbrella of Gaia-X, funded by the German Federal Ministry for Economic Affairs and Climate Action (BMWK). With the programme's conclusion, the Federation Services were transferred to the Eclipse Foundation under the **XFSC** (Cross Federation Services Components) project, where they continue to be maintained and evolved. Historical references to "GXFS" in this codebase therefore refer to the original programme; "XFSC" refers to the current Eclipse project.
+
 |Credential (formerly Self-Description / SD)
 |A credential is a Verifiable Presentation (VP) or standalone Verifiable Credential (VC) that expresses characteristics of a Resource, Service Offering or Participant and describes properties and Claims which are linked to the Identifier. The catalogue accepts both forms; in strict/Gaia-X mode a VP wrapper is required. In the Gaia-X specificationfootnote:[https://docs.gaia-x.eu/technical-committee/identity-credential-access-management/24.07/credential_format/[Gaia-X Identity, Credential and Access Management / Credential format]], this concept replaces what was previously called a "Self-Description". At the catalogue's API and storage level, credentials are managed as **Assets**.
 
@@ -133,7 +136,7 @@ The identifier must be a valid IRI (see ADR 7).
 |The profile configuration returned by `TrustFrameworkProfileResolver` for a given bundle, formed per call by layering the Bundle Config Override (if present) on top of the bundle YAML, with hard-coded defaults filling the remainder. Consumed by the compliance pipeline; also surfaced to the admin UI together with the set of identifiers whose effective value currently comes from an override. See ADR 19.
 
 |Schema Module
-|One of the four runtime-toggleable schema languages exposed on the admin schema-modules page: `SHACL`, `JSON_SCHEMA`, `XML_SCHEMA`, `OWL`. Each toggle persists to the `admin_config` table under `schema.module.<MODULE>.enabled`. Validators (SHACL, JSON Schema, XML Schema) gate the corresponding validator at on-demand validation and credential verification; the OWL toggle gates the runtime composite-ontology subclass walk in base-class resolution. See ADR 16.
+|One of the four runtime-toggleable schema languages exposed on the admin schema-modules page: SHACL, JSON Schema, XML Schema, and OWL. Each toggle is persisted by the catalogue and survives restarts. The first three gate the corresponding validator at on-demand validation and credential verification; the OWL toggle gates the runtime composite-ontology subclass walk in base-class resolution. See ADR 16.
 
 |OWL Module Toggle
 |The admin toggle that gates the `rdfs:subClassOf+` walk over runtime-uploaded ontologies during base-class resolution. When off, the catalogue resolves only types reachable through the registry index and `additional_roots`; credentials whose type relies on a runtime-uploaded ontology fall through to `ResolvedBaseClass.UNKNOWN` and are rejected by the verification entry point with `400 Bad Request`. Registry-direct types keep resolving. See ADR 16.

--- a/federated-catalogue/src/docs/architecture/chapters/12_glossary.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/12_glossary.adoc
@@ -145,6 +145,21 @@ The identifier must be a valid IRI (see ADR 7).
 |The third tier of base-class resolution: a SPARQL `rdfs:subClassOf+` traversal performed by `ClaimValidator.resolveSubjectBaseClass` against the runtime composite ontology, run only when the registry index and `additional_roots` (tiers 1 and 2) do not recognise a credential's type. Gated by the OWL schema-module toggle (see ADR 16).
 
 |Composite Ontology
-|The in-memory Jena `OntModel` formed by union of every `ONTOLOGY`-type schema row currently stored in the catalogue. Cached process-wide by `SchemaStoreImpl.COMPOSITE_SCHEMAS` and invalidated on schema add/update/delete/clear. Consumed by the subclass walk during role resolution and by the on-demand validation endpoint when returning the composite SHAPE graph.
+|The in-memory Jena `OntModel` formed by union of every `ONTOLOGY`-type schema row currently stored in the catalogue. Cached process-wide and invalidated on schema add/update/delete/clear. Consumed by the subclass walk during role resolution and by the on-demand validation endpoint when returning the composite SHAPE graph.
+
+|SRS (Software Requirements Specification)
+|The authoritative requirements document for the Federated Catalogue, owned outside this architecture document. SRS-resident requirements are identified by IDs of the form `CAT-FR-<area>-<n>` (functional) or `CAT-NFR-<n>` (non-functional); the architecture document refers to these IDs in chapter 1 only and otherwise speaks in terms of the underlying architectural concept.
+
+|EVC / EVP (Enveloped Verifiable Credential / Presentation)
+|W3C VC 2.0 wrappers that carry a JWT-encoded credential or presentation inside a JSON-LD outer envelope (using a `data:` URI). They preserve the JSON-LD shape required by the W3C VC 2.0 pipeline while keeping the cryptographic signature in the inner JWT. The catalogue treats EVC/EVP wrappers as VC 2.0 content and routes them through the generic VC 2.0 processor.
+
+|Audit Shadow (Hibernate Envers)
+|A shadow table maintained automatically by Hibernate Envers alongside an audited entity. Every insert, update, and delete on the source entity creates a snapshot row in its audit shadow, linked to a global revision entity that timestamps each operation. Used by the catalogue to record asset, schema-file, and schema-term history. The exact shadow-table column shape is defined in the Liquibase changelog, not in this document.
+
+|Provenance Credential
+|A credential the catalogue stores alongside an asset to record where the asset came from (issuer, timestamp, supporting attestations). Provenance credentials are persisted in a dedicated relational entity and are deleted together with the asset they belong to via the asset-deletion event.
+
+|RDF-star
+|An RDF 1.2 extension that allows triples themselves to be the subject or object of other triples ("statements about statements"), written with the `<<( s p o )>>` syntax. The catalogue's Fuseki graph backend stores credential claims as RDF-star quoted triples so that the originating credential subject can be attached to each claim without losing graph-query semantics. Queries against the Fuseki backend must use SPARQL-star (SPARQL extended for RDF-star).
 
 |===

--- a/federated-catalogue/src/docs/architecture/chapters/13_appendix.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/13_appendix.adoc
@@ -319,7 +319,7 @@ SELECT ?s ?p ?o WHERE {
 ==== Neo4j (openCypher) reference
 
 The Neo4j backend remains available; queries are sent to `POST /query` with `Content-Type: application/opencypher-query`.
-The example below is the openCypher equivalent of <<anchor:_all_nodes_and_relationships,All Nodes and Relationships>>.
+The example below is the openCypher equivalent of <<_all_nodes_and_relationships,All Nodes and Relationships>>.
 
 [source,cypher]
 ----

--- a/federated-catalogue/src/docs/architecture/chapters/13_appendix.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/13_appendix.adoc
@@ -15,7 +15,9 @@ ifndef::imagesdir[:imagesdir: ../../images]
 
 These examples demonstrate how to interact with the xref:05_building_block_view#_graph_database[Graph Database].
 
-NOTE: The examples below use **openCypher** syntax, which applies to the **Neo4j** backend (`graphstore.impl=neo4j`). Send these with `Content-Type: application/opencypher-query`. When using the **Fuseki** backend (`graphstore.impl=fuseki`), equivalent queries must be expressed in **SPARQL-star** syntax and sent with `Content-Type: application/sparql-query`. See <<sparql_star_examples>> for SPARQL-star equivalents.
+NOTE: The examples below use **SPARQL-star** syntax, which applies to the **Fuseki** backend — the default in `dev.env`.
+Send these to `POST /query` with `Content-Type: application/sparql-query`.
+The **Neo4j** backend remains available; an equivalent openCypher example is shown in <<opencypher_example,Neo4j (openCypher) reference>>.
 
 All of the following examples have the same structure:
 
@@ -32,292 +34,297 @@ Get all nodes and relationships between them.
 
 ===== Data
 
-Three Participants (legal persons): https://gitlab.com/gaia-x/data-infrastructure-federation-services/cat/fc-service/-/tree/main/examples/queries/test-issuer.jsonld[1], https://gitlab.com/gaia-x/data-infrastructure-federation-services/cat/fc-service/-/tree/main/examples/queries/test-issuer2.jsonld[2], https://gitlab.com/gaia-x/data-infrastructure-federation-services/cat/fc-service/-/tree/main/examples/queries/test-issuer3.jsonld[3].
+Three Participants (legal persons): https://github.com/eclipse-xfsc/federated-catalogue/blob/main/examples/queries/test-issuer.jsonld[1], https://github.com/eclipse-xfsc/federated-catalogue/blob/main/examples/queries/test-issuer2.jsonld[2], https://github.com/eclipse-xfsc/federated-catalogue/blob/main/examples/queries/test-issuer3.jsonld[3].
+See the link:{repo-link}/examples/queries/README.md[queries README] for the VC-JWT signing and submission flow.
 
-This listing shows the full structure of a credential (Verifiable Presentation or standalone Verifiable Credential) in JSON-LD.  The following listings will focus on the credential subject, as it is only the claims about that subject which are extracted into the Graph Database.
+This listing shows the full structure of a Verifiable Credential payload in JSON-LD.
+The following listings will focus on the credential subject, as it is only the claims about that subject which are extracted into the Graph Database.
+The payload is signed as a VC-JWT before submission to `/assets` (see the queries README).
 
 [source,json]
 ----
 {
-  "@context": ["https://www.w3.org/ns/credentials/v2", "https://w3id.org/gaia-x/2511#"],
-  "type": "VerifiablePresentation",
-  "verifiableCredential": [{
-    "@context": ["https://www.w3.org/ns/credentials/v2", "https://w3id.org/gaia-x/2511#"],
-    "type": ["VerifiableCredential", "gx:LegalPerson"],
-    "issuer": "did:web:example.com",
-    "validFrom": "2026-01-30T00:00:00Z",
-    "validUntil": "2027-12-31T23:59:59Z",
-    "credentialSubject": {
-      "@context": {
-        "gx": "https://w3id.org/gaia-x/2511#",
-        "vcard": "http://www.w3.org/2006/vcard/ns#"
-      },
-      "@id": "did:web:test-issuer.example.com",
-      "@type": "gx:LegalPerson",
-      "gx:registrationNumber": "DE182676944",
-      "gx:legalAddress": {
-        "@type": "vcard:Address",
-        "vcard:country": "DE",
-        "vcard:locality": "Köln",
-        "vcard:postal-code": "50825",
-        "vcard:street-address": "Lichtstraße 43h"
-      },
-      "gx:headquarterAddress": {
-        "@type": "vcard:Address",
-        "vcard:country": "DE",
-        "vcard:locality": "Köln",
-        "vcard:postal-code": "50825",
-        "vcard:street-address": "Lichtstraße 43h"
-      },
-      "gx:legalName": "eco - Verband der Internetwirtschaft e.V.",
-      "gx:name": "eco - Verband der Internetwirtschaft"
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://w3id.org/gaia-x/2511#",
+    { "schema": "https://schema.org/", "vcard": "http://www.w3.org/2006/vcard/ns#" }
+  ],
+  "id": "https://www.example.org/credentials/legal-person-1.json",
+  "type": ["VerifiableCredential", "gx:LegalPerson"],
+  "issuer": "did:web:example.org",
+  "validFrom": "<ISO-8601 issuance timestamp, illustrative>",
+  "validUntil": "<ISO-8601 expiration timestamp, illustrative>",
+  "credentialSubject": {
+    "id": "https://www.example.org/participants/test-issuer-1",
+    "type": "gx:LegalPerson",
+    "schema:name": "deltaDAO AG",
+    "gx:registrationNumber": { "id": "https://www.example.org/participants/test-issuer-1/registration" },
+    "gx:legalAddress": {
+      "type": "gx:Address",
+      "gx:countryCode": "DE",
+      "vcard:locality": "Hamburg",
+      "vcard:postal-code": "22303",
+      "vcard:street-address": "Geibelstraße 46b"
+    },
+    "gx:headquartersAddress": {
+      "type": "gx:Address",
+      "gx:countryCode": "DE",
+      "vcard:locality": "Hamburg",
+      "vcard:postal-code": "22303",
+      "vcard:street-address": "Geibelstraße 46b"
     }
-  }]
+  }
 }
 
-... # two more with the same structure, just different attribute values
+... # two more participants with the same structure, different addresses
 ----
 
 ===== Query
 
-[source,cypher]
+[source,sparql]
 ----
-MATCH (m) -[relation]-> (n) RETURN m, relation, n
+PREFIX gx: <https://w3id.org/gaia-x/2511#>
+SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 100
 ----
 
 ===== Output
 
-----
-[{m={legalName=eco - Verband der Internetwirtschaft e.V.,
-     name=eco - Verband der Internetwirtschaft,
-     claimsGraphUri=[http://example.org/test-issuer]},
-  n={country=DE,
-     postal-code=50825,
-     claimsGraphUri=[http://example.org/test-issuer],
-     street-address=Lichtstraße 43h,
-     locality=Köln},
-  relation=legalAddress}, 
- {m={legalName=eco - Verband der Internetwirtschaft e.V.,
-     name=eco 2,
-     claimsGraphUri=[http://example.org/test-issuer2]},
-  n={country=DE,
-     postal-code=11111,
-     claimsGraphUri=[http://example.org/test-issuer2],
-     street-address=1 Test Street,
-     locality=Cologne},
-  relation=legalAddress}, 
- {m={legalName=eco - Verband der Internetwirtschaft e.V.,
-     name=eco 3,
-     claimsGraphUri=[http://example.org/test-issuer3]},
-  n={country=DE,
-     postal-code=22222,
-     claimsGraphUri=[http://example.org/test-issuer3],
-     street-address=2 Test Street,
-     locality=Kölle},
-  relation=legalAddress}]
-----
+A standard SPARQL solution sequence; one row per triple.
+The interesting rows (legal/headquarters address and `gx:subOrganisationOf` edges) include:
 
-Note that, via the special property +claimsGraphUri+ all nodes have a link back to the ID of the credential subject from which they have been extracted.  This way, it is possible to obtain further information about the respective asset from the Metadata Store.
+[options="header",cols="3,2,3"]
+|===
+| ?s | ?p | ?o
+
+| `<.../participants/test-issuer-1>` | `gx:legalAddress`        | _bnode_ (Hamburg address)
+| `<.../participants/test-issuer-1>` | `gx:headquartersAddress` | _bnode_ (Hamburg address)
+| `<.../participants/test-issuer-1>` | `schema:name`            | `"deltaDAO AG"`
+| `<.../participants/test-issuer-2>` | `gx:legalAddress`        | _bnode_ (Dresden address)
+| `<.../participants/test-issuer-3>` | `gx:subOrganisationOf`   | `<.../participants/test-issuer-1>`
+|===
+
+To recover the asset IRI each triple was extracted from, Fuseki annotates every claim with `cred:credentialSubject` as an RDF-star quoted triple.
+See <<provenance_via_rdf_star>>.
 
 ==== Simple Relationship
 
-Check whether +ServiceOffering+ has two properties, one of which has a value with a certain label (i.e., identifier), and return the URI of the +ServiceOffering+.
+Return Service Offerings that are provided by a given Legal Person.
 
 ===== Data
 
-One Service Offering; see https://gitlab.com/gaia-x/data-infrastructure-federation-services/cat/fc-service/-/tree/main/examples/queries/serviceElasticSearch[file].
+Two Service Offerings, both provided by `test-issuer-1`: https://github.com/eclipse-xfsc/federated-catalogue/blob/main/examples/queries/credentialSubject2.jsonld[1], https://github.com/eclipse-xfsc/federated-catalogue/blob/main/examples/queries/serviceElasticSearch.jsonld[2].
+The Legal Person credential https://github.com/eclipse-xfsc/federated-catalogue/blob/main/examples/queries/test-issuer.jsonld[test-issuer.jsonld] must already be in the graph.
 
 [source,json]
 ----
 {
-  "@id": "http://w3id.org/gaia-x/indiv#serviceElasticSearch.json",
-  "@type": "gx:ServiceOffering",
-  "ex:some_property": {
-    "ex:some_other_property": {
-      "@value": "ex:some_service",
-      "@type": "gx:ServiceOffering"
-    }
-  },
-  "gx:name": "Elastic Search DB"
+  "id": "https://www.example.org/service-offerings/elasticsearch",
+  "type": "gx:ServiceOffering",
+  "schema:name": "Elastic Search DB",
+  "gx:providedBy": { "id": "https://www.example.org/participants/test-issuer-1" }
 }
 ----
 
 ===== Query
 
-[source,cypher]
+[source,sparql]
 ----
-MATCH (o)<-[:some_other_property]-(n:ServiceOffering)-[:some_property]->(m) WHERE o.label=resource24 RETURN n.uri
+PREFIX gx:     <https://w3id.org/gaia-x/2511#>
+PREFIX schema: <https://schema.org/>
+
+SELECT ?service ?name WHERE {
+  ?service a gx:ServiceOffering ;
+           gx:providedBy <https://www.example.org/participants/test-issuer-1> ;
+           schema:name ?name .
+}
 ----
 
 ===== Output
 
-----
-[{n.uri=http://ex.com/credentialSubject2}]
-----
+[options="header"]
+|===
+| ?service | ?name
+| `<.../service-offerings/service-1>`     | `"Example Compute Service"`
+| `<.../service-offerings/elasticsearch>` | `"Elastic Search DB"`
+|===
 
 ==== Essential Attributes
 
-Return the type, name, legal address and legal name of a (+Participant+) credential.
+Return the type, name and legal address of a Participant credential.
 
 ===== Data
 
-A Participant like used in the query for <<anchor:_all_nodes_and_relationships,all nodes and relationships>>; see https://gitlab.com/gaia-x/data-infrastructure-federation-services/cat/fc-service/-/tree/main/examples/queries/test-issuer2.jsonld[file].
+A Legal Person; see https://github.com/eclipse-xfsc/federated-catalogue/blob/main/examples/queries/test-issuer2.jsonld[test-issuer2.jsonld].
 
 [source,json]
 ----
 {
-  "@id": "ex:test-issuer2",
-  "@type": "gx:LegalPerson",
+  "id": "https://www.example.org/participants/test-issuer-2",
+  "type": "gx:LegalPerson",
+  "schema:name": "deltaDAO Dresden GmbH",
   "gx:legalAddress": {
-    "@type": "vcard:Address",
-    "vcard:country": "DE",
-    "vcard:locality": "Cologne",
-    "vcard:postal-code": "11111",
-    "vcard:street-address": "1 Test Street"
-  },
-  "gx:legalName": "eco - Verband der Internetwirtschaft e.V.",
-  "gx:name": "eco 2"
-}
-----
-
-===== Query
-
-[source,cypher]
-----
-MATCH (m)-[:legalAddress]->(n) RETURN LABELS(m) as type, n as legalAddress, m.legalName as legalName, m.name as name
-----
-
-===== Output
-
-----
-[{legalName=eco - Verband der Internetwirtschaft e.V.,
-  name=eco 2,
-  type=[Resource,LegalPerson],
-  legalAddress={country=DE,
-                postal-code=11111,
-                claimsGraphUri=[http://example.org/test-issuer2],
-                street-address=1 Test Street,
-                locality=Cologn}}]
-----
-
-==== Entity having a Property
-
-Obtain an entity (as node) that has some property.
-
-===== Data
-
-Two Service Offerings, which both match the query: https://gitlab.com/gaia-x/data-infrastructure-federation-services/cat/fc-service/-/tree/main/examples/queries/credentialSubject2[1], https://gitlab.com/gaia-x/data-infrastructure-federation-services/cat/fc-service/-/tree/main/examples/queries/serviceElasticSearch[2].
-
-[source,json]
-----
-{
-  "@id": "http://w3id.org/gaia-x/indiv#serviceElasticSearch.json",
-  "@type": "gx:ServiceOffering",
-  "ex:some_property": {
-    "ex:some_other_property": {
-      "@value": "ex:some_service",
-      "@type": "gx:ServiceOffering"
-    }
-  },
-  "gx:name": "Elastic Search DB"
-}
-
-...
-
-{
-  "@id": "ex:credentialSubject2",
-  "@type": "gx:ServiceOffering",
-  "ex:some_property": {
-    "@value": "http://ex.com/resource23",
-    "@type": "xsd:anyURI"
+    "type": "gx:Address",
+    "gx:countryCode": "DE",
+    "vcard:region": "Sachsen",
+    "vcard:locality": "Dresden",
+    "vcard:postal-code": "01069",
+    "vcard:street-address": "Pragerstraße 12"
   }
 }
 ----
 
 ===== Query
 
-[source,cypher]
+[source,sparql]
 ----
-MATCH (n)-[:some_property]->(m) RETURN n
+PREFIX gx:     <https://w3id.org/gaia-x/2511#>
+PREFIX schema: <https://schema.org/>
+PREFIX vcard:  <http://www.w3.org/2006/vcard/ns#>
+
+SELECT ?name ?countryCode ?region ?locality ?postalCode ?streetAddress WHERE {
+  <https://www.example.org/participants/test-issuer-2> a gx:LegalPerson ;
+    schema:name ?name ;
+    gx:legalAddress ?addr .
+  ?addr gx:countryCode      ?countryCode ;
+        vcard:locality      ?locality ;
+        vcard:postal-code   ?postalCode ;
+        vcard:street-address ?streetAddress .
+  OPTIONAL { ?addr vcard:region ?region . }
+}
 ----
 
 ===== Output
 
-----
-[{n={claimsGraphUri=[http://w3id.org/gaia-x/indiv#serviceElasticSearch.json]}},
- {n={claimsGraphUri=[http://ex.com/credentialSubject2]}}]
-----
+[options="header"]
+|===
+| ?name | ?countryCode | ?region | ?locality | ?postalCode | ?streetAddress
+| `"deltaDAO Dresden GmbH"` | `"DE"` | `"Sachsen"` | `"Dresden"` | `"01069"` | `"Pragerstraße 12"`
+|===
 
-==== Entities by Name
+==== Entity having a Property
 
-Return all entities having a given name.
+Obtain all Service Offerings that declare a `dependsOn` relationship to another service.
 
 ===== Data
 
-One Service Offering; see https://gitlab.com/gaia-x/data-infrastructure-federation-services/cat/fc-service/-/tree/main/examples/queries/credentialSubject2[file].
+Two Service Offerings: https://github.com/eclipse-xfsc/federated-catalogue/blob/main/examples/queries/credentialSubject2.jsonld[1] (`service-1`, has no `dependsOn`), and https://github.com/eclipse-xfsc/federated-catalogue/blob/main/examples/queries/serviceElasticSearch.jsonld[2] (`elasticsearch`, depends on `service-1`).
 
 [source,json]
 ----
 {
-  "@id": "http://w3id.org/gaia-x/indiv#serviceElasticSearch.json",
-  "@type": "gx:ServiceOffering",
-  ...
-  "gx:name": "Elastic Search DB"
+  "id": "https://www.example.org/service-offerings/elasticsearch",
+  "type": "gx:ServiceOffering",
+  "schema:name": "Elastic Search DB",
+  "gx:dependsOn": { "id": "https://www.example.org/service-offerings/service-1" }
+}
+
+...
+
+{
+  "id": "https://www.example.org/service-offerings/service-1",
+  "type": "gx:ServiceOffering",
+  "schema:name": "Example Compute Service"
 }
 ----
 
 ===== Query
 
-[source,cypher]
+[source,sparql]
 ----
-MATCH (n:ServiceOffering) WHERE n.name = "Elastic Search DB" RETURN n.uri LIMIT 25
+PREFIX gx: <https://w3id.org/gaia-x/2511#>
+
+SELECT ?dependent ?dependency WHERE {
+  ?dependent a gx:ServiceOffering ;
+             gx:dependsOn ?dependency .
+  ?dependency a gx:ServiceOffering .
+}
 ----
 
 ===== Output
 
+[options="header"]
+|===
+| ?dependent | ?dependency
+| `<.../service-offerings/elasticsearch>` | `<.../service-offerings/service-1>`
+|===
+
+==== Entities by Name
+
+Return all entities with a given `schema:name` value.
+
+===== Data
+
+One Service Offering; see https://github.com/eclipse-xfsc/federated-catalogue/blob/main/examples/queries/serviceElasticSearch.jsonld[serviceElasticSearch.jsonld].
+
+[source,json]
 ----
-[{n.uri=http://w3id.org/gaia-x/indiv#serviceElasticSearch.json}]
+{
+  "id": "https://www.example.org/service-offerings/elasticsearch",
+  "type": "gx:ServiceOffering",
+  "schema:name": "Elastic Search DB"
+}
 ----
 
-[[sparql_star_examples]]
-==== SPARQL-star Examples (Fuseki backend)
-
-The following examples show equivalent queries for the Fuseki backend using SPARQL-star syntax. These are sent via `POST /query` with `Content-Type: application/sparql-query`.
-
-===== All triples
-
-Retrieve all triples stored in the graph:
+===== Query
 
 [source,sparql]
 ----
-SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 100
+PREFIX schema: <https://schema.org/>
+
+SELECT ?entity WHERE {
+  ?entity schema:name "Elastic Search DB" .
+}
+LIMIT 25
 ----
 
-===== All claims with asset IRI
+===== Output
 
-Retrieve all claims together with the asset IRI they belong to, using RDF-star syntax.
-The `cred:credentialSubject` predicate is the Fuseki backend's internal annotation that records the source asset IRI for each triple — for Verifiable Credentials this is the `credentialSubject` IRI; for non-credential RDF assets (Turtle, N-Triples, RDF/XML, JSON-LD) it is the asset's `@id` or UUID URN assigned by `IriGenerator`:
+[options="header"]
+|===
+| ?entity
+| `<.../service-offerings/elasticsearch>`
+|===
+
+[[provenance_via_rdf_star]]
+==== Provenance via RDF-star
+
+The Fuseki backend annotates every extracted claim with the source asset IRI it was derived from, using the `cred:credentialSubject` predicate against an RDF-star quoted triple.
+For Verifiable Credentials this is the `credentialSubject` IRI; for non-credential RDF assets (Turtle, N-Triples, RDF/XML, JSON-LD) it is the asset's `@id` or the UUID URN assigned by `IriGenerator`.
+
+===== All claims with their source asset
 
 [source,sparql]
 ----
 PREFIX cred: <https://www.w3.org/2018/credentials#>
-SELECT ?s ?p ?o ?cs
-WHERE {
-  <<(?s ?p ?o)>> cred:credentialSubject ?cs
+
+SELECT ?s ?p ?o ?asset WHERE {
+  <<(?s ?p ?o)>> cred:credentialSubject ?asset .
 }
 LIMIT 100
 ----
 
-===== Claims for a specific asset IRI
-
-Retrieve all claims belonging to a specific asset, identified by its IRI.
-Works for both Verifiable Credentials and non-credential RDF assets:
+===== Claims belonging to a specific asset
 
 [source,sparql]
 ----
 PREFIX cred: <https://www.w3.org/2018/credentials#>
-SELECT ?s ?p ?o
-WHERE {
-  <<(?s ?p ?o)>> cred:credentialSubject <http://example.org/my-asset-iri>
+
+SELECT ?s ?p ?o WHERE {
+  <<(?s ?p ?o)>> cred:credentialSubject
+    <https://www.example.org/participants/test-issuer-1> .
 }
 ----
+
+[[opencypher_example]]
+==== Neo4j (openCypher) reference
+
+The Neo4j backend remains available; queries are sent to `POST /query` with `Content-Type: application/opencypher-query`.
+The example below is the openCypher equivalent of <<anchor:_all_nodes_and_relationships,All Nodes and Relationships>>.
+
+[source,cypher]
+----
+MATCH (m)-[relation]->(n) RETURN m, relation, n
+----
+
+Property names in the Neo4j projection are derived from the local part of each predicate IRI (e.g. `schema:name` → `name`, `gx:legalAddress` → `legalAddress` as edge label, `vcard:postal-code` → `postal-code`).
+The +claimsGraphUri+ property on each node links back to the asset IRI the claims were extracted from — the openCypher counterpart to `cred:credentialSubject` in <<provenance_via_rdf_star>>.


### PR DESCRIPTION
## 🚀 Summary

Sweep across the arc42 architecture document for the federated catalogue to make it more durable as a reference for new contributors and maintainers. Three passes were applied in order: (1) **decouple the prose from implementation detail** — SQL DDL, Liquibase changeset names, HTTP status codes in prose, `federated-catalogue.*=value` property pins, `/latest/` Gaia-X links — replaced with conceptual descriptions that point at the OpenAPI spec, the wiki Installation & Configuration Guide, and the Liquibase changelog as the actual sources of truth; (2) a **linear-readability pass** that added chapter leads, fixed a handful of broken `<<…>>` cross-references and an anchor typo, repaired a garbled section opener in chapter 6, documented the gap in ADR numbering (10 → 15), and extended the glossary with SRS, EVC/EVP, Audit Shadow, Provenance Credential, and RDF-star entries; (3) follow-up work on out-of-order definitions in chapter 5 (forward pointers to `GraphStore`, the trust-framework-bundle / base-class concept, and `RdfClaim`) and a **carve-out of the Keycloak operator cookbook from chapter 7** into the wiki Administration Guide, leaving a four-point architectural framing behind.

Side effects: Gaia-X external links pinned per Loire sub-document (Architecture 25.05, ICAM 24.07, Compliance 25.10, Data Exchange 25.07, Ontology 25.11) so a future Gaia-X release does not silently reinterpret statements authored against Loire; appendix example-query links repaired and verified against the source repository; example credential timestamps replaced with illustrative placeholders; the Loire / Danube / \`danubetech\` library naming collision is now disambiguated in chapter 4.

## ✅ What's Changed

- [x] Documentation updated
- [ ] Feature implemented / Bug fixed
- [ ] Tests added or updated
- [ ] Code formatted and linted

## 🧪 How to Test

1. Build the architecture document locally (or via the \`buildDocs\` workflow in \`eclipse-xfsc/docs\`) and confirm it builds cleanly without AsciiDoctor warnings.
2. Skim the rendered HTML / PDF top-to-bottom as a first-time reader; each chapter should now open with a short orienting paragraph and the chapter-5 forward references should resolve to a downstream section.
3. Spot-check every external link in chapter 3 (Gaia-X document set), chapter 7 (wiki Administration Guide, wiki Configuration Guide), and chapter 13 (example-query files under \`eclipse-xfsc/federated-catalogue/examples/queries/\`) — all should resolve to a live target.
4. Search the chapters for \`HTTP 4\`, \`federated-catalogue.\`, \`admin_config\`, \`assets_aud\`, \`/latest/\`, \`Liquibase changeset \\\`\`, and \`Jena 5.5\`; results should be limited to the documented historical or operator-facing exceptions (e.g. config-name table in the wiki Configuration Guide).
5. Verify cross-references with \`grep -nE '<<[a-z_]+'\` and confirm every anchor exists.
6. Open the Keycloak section of chapter 7 and confirm it reads as architectural framing only; the step-by-step Keycloak procedures should now live in the wiki FC Administration Guide.

## 🔍 Related Issues

Closes #<issue-number>
Related to #<other-issue>

## 📸 Screenshots (if applicable)

<!-- Not a UI change. -->

## 📋 Checklist

- [ ] I've tested my code locally
- [ ] I've added tests if needed
- [ ] I've updated documentation if necessary
- [ ] My changes follow the project's coding style