### PR TITLE
Reflect PROV-O alignment, cascade-by-IRI, version-counter semantics

### DIFF
--- a/federated-catalogue/src/docs/architecture/chapters/05_building_block_view.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/05_building_block_view.adoc
@@ -1673,29 +1673,18 @@ Found if no HR asset is linked yet). Content retrieval is exposed via
 surfaced in the metadata response as `humanReadableId` (on MR assets) and `machineReadableId`
 (on HR assets).
 
-Accepted content types for human-readable representations:
+Accepted content types for human-readable representations are governed by a configurable two-layer scheme:
 
-[options="header",cols="1,2"]
-|===
-| MIME type | Format
-| `application/pdf` | PDF
-| `application/vnd.openxmlformats-officedocument.wordprocessingml.document` | DOCX
-| `text/html` | HTML
-| `text/plain` | Plain text
-|===
+* an **allowlist** that admits broad MIME families typically used for human-facing attachments (textual formats, common office and document formats), and
+* a **denylist** that explicitly rejects scripting and active-content subtypes — `image/svg+xml`, JavaScript/ECMAScript/VBScript flavours, and similar — even when they would otherwise match the family allowlist.
 
-These are the default values of `federated-catalogue.assets.human-readable-content-types`.
-The same allowlist is enforced for both `POST /assets/{mrId}/human-readable` and
+The same scheme is enforced for both `POST /assets/{mrId}/human-readable` and
 `PUT /assets/{mrId}/human-readable`.
-
-* `application/pdf` and `application/vnd.openxmlformats-officedocument.wordprocessingml.document`
-  cover the main document formats typically exchanged as human-facing attachments.
-* `text/html` supports web-renderable human-readable pages.
-* `text/plain` supports lightweight textual explanations, notes, or readme-style content.
-* Validation is strict against the configured `Content-Type` header. Unsupported types are
-  rejected with `400 Bad Request`.
-* A missing `Content-Type` is treated as `application/octet-stream`, which is not accepted by
-  default and is therefore rejected as well.
+Validation is strict against the configured `Content-Type`
+header; unsupported or denylisted types are rejected with `400 Bad Request`.
+A missing
+`Content-Type` is treated as `application/octet-stream`, which is not accepted by default.
+The current default allowlist, denylist and the configuration keys that override them are documented in the OpenAPI specification.
 
 This restriction is intentional: the human-readable link endpoint is meant for documents that a
 person can read directly. Generic binary files can still be uploaded as regular assets, but they

--- a/federated-catalogue/src/docs/architecture/chapters/05_building_block_view.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/05_building_block_view.adoc
@@ -1019,6 +1019,10 @@ The `AssetStore` provides two parallel access paths: **hash-based** methods (int
 The `deleteAsset(hash)` and `changeLifeCycleStatus(hash, status)` methods are the deliberate exceptions — both remain hash-based to guarantee unambiguous single-row targeting.
 See ADR 7, Hash-Based Mutation Operations Exception. `deleteAsset` publishes an `AssetDeletedEvent` after the row deletion, triggering cascade cleanup of associated validation results and provenance credentials (see <<_validation_result_storage>>).
 
+In addition to the hash-based path, the asset store exposes `deleteByAssetId(id)` — an idempotent cascade keyed by the asset IRI. It removes the live row, its human-readable companion, and (via the same `AssetDeletedEvent`) the validation-result and provenance-credential rows attached to the asset. A second call against the same identifier resolves to a no-op so that demo scripts and integration test fixtures can reset state without environment teardown. Cross-participant access is gated on the live row's issuer when present; an unknown identifier always succeeds with `204` and reveals nothing about the catalogue's contents. The underlying audit log of past content revisions is preserved.
+
+The asset version counter is defined as the number of distinct content hashes observed across the entity's audit history. Saves that change non-content fields (linking a human-readable companion, lifecycle-status transitions, last-modified bookkeeping) reuse an existing hash and therefore do not advance the counter. This matches the SRS rule that linking a sub-resource to an asset must not produce a new asset version.
+
 The `IriGenerator` assigns IRIs before storage: it extracts IRIs from RDF content (`credentialSubject.id`, `@id`, ontology/shapes/vocabulary IRIs) or generates UUID URNs (RFC 4122) for non-RDF assets and as fallback. The `IriValidator` checks all assigned IRIs against supported formats (DIDs, UUID URNs, generic URNs, HTTP/HTTPS IRIs) — returning `true`/`false`. Callers decide how to handle invalid IRIs (fallback to UUID URN, or reject the request).
 
 The asset metadata is stored in the metadata store, using the following data model:

--- a/federated-catalogue/src/docs/architecture/chapters/06_runtime_view.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/06_runtime_view.adoc
@@ -781,9 +781,14 @@ sequenceDiagram
 
 Stores a W3C VC 2.0 JSON-LD or VC-JWT provenance credential against a specific asset version. The optional `?version=X` query parameter targets a historical version (1-based ordinal); omitting it targets the current version. Attaching a provenance credential does **not** advance the asset's version counter — the counter reflects distinct content hashes, not metadata or sub-resource events.
 
-`credentialSubject.id` in the VC must equal `{assetId}:v{N}` — any mismatch returns 400. VC 1.1 payloads and payloads using the CAT-internal namespace are also rejected with 400. A duplicate `credentialId` (VC `id` field) returns 409.
+Two W3C-PROV-O credential shapes are accepted:
 
-`credentialSubject` MAY declare any combination of the recognised PROV-O predicates: `prov:wasGeneratedBy`, `prov:wasDerivedFrom`, `prov:wasAttributedTo`, `prov:wasRevisionOf`, `prov:generated`, `prov:used`, `prov:wasAssociatedWith`, `prov:actedOnBehalfOf`. Both compact (`prov:X`) and expanded (`http://www.w3.org/ns/prov#X`) forms are accepted. When a graph store is active, **every** recognised predicate is projected as its own triple under the versioned asset IRI `{assetId}:v{N}`; the predicate that appears first on `credentialSubject` is also written to the relational store as the row's primary type discriminator for filtering.
+* **Entity-centric** — `credentialSubject.id` is the versioned asset IRI itself, and PROV-O predicates describe the asset as the subject (e.g. `prov:wasGeneratedBy`, `prov:wasDerivedFrom`).
+* **Activity-centric** — `credentialSubject.id` is the activity's own IRI, and at least one PROV-O predicate (typically `prov:generated` or `prov:used`) points back at the versioned asset so the activity is reachable from it.
+
+Each shape is projected to the graph under the IRI of its own `credentialSubject`.
+The list of recognised PROV-O predicates and their accepted forms (compact or expanded) is documented in the OpenAPI specification.
+VC 1.1 payloads and payloads using the CAT-internal namespace are rejected with 400; a duplicate `credentialId` (VC `id` field) returns 409.
 
 [mermaid, width=2000]
 ....
@@ -1139,6 +1144,9 @@ When calling `GET /query` a HTML page with a query input form is displayed.
 The query endpoint uses the `Content-Type` header to select the query language: `application/opencypher-query` for openCypher (Neo4j backend) or `application/sparql-query` for SPARQL-star (Fuseki backend). The request body is raw query text (not a JSON wrapper). Queries in a language not supported by the active backend are rejected with HTTP 415 (Unsupported Media Type), including a message that names the active backend, the supported language and the expected `Content-Type`. When the graph store is disabled (`graphstore.impl=none`), queries are rejected with HTTP 503 (Service Unavailable).
 
 Only read queries are allowed. Write queries (e.g., `CREATE`/`DELETE` in openCypher, `INSERT`/`DELETE` in SPARQL) are rejected with HTTP 500.
+
+For SPARQL queries the response format is content-negotiated via the `Accept` header: the catalogue's own paginated envelope (`application/json`) remains the default, and the W3C SPARQL 1.1 Results JSON format (`application/sparql-results+json`) is offered as an alternative for SPARQL-tooling compatibility.
+Backends that cannot produce the standard format respond with HTTP 406 to the alternative request.
 
 [mermaid, width=2000]
 ....

--- a/federated-catalogue/src/docs/architecture/chapters/06_runtime_view.adoc
+++ b/federated-catalogue/src/docs/architecture/chapters/06_runtime_view.adoc
@@ -779,11 +779,11 @@ sequenceDiagram
 
 ==== Attaching a Provenance Credential
 
-Stores a W3C VC 2.0 JSON-LD or VC-JWT provenance credential against a specific asset version. The optional `?version=X` query parameter targets a historical version (1-based ordinal); omitting it targets the current version. The write does **not** produce a new Envers revision on the asset.
+Stores a W3C VC 2.0 JSON-LD or VC-JWT provenance credential against a specific asset version. The optional `?version=X` query parameter targets a historical version (1-based ordinal); omitting it targets the current version. Attaching a provenance credential does **not** advance the asset's version counter — the counter reflects distinct content hashes, not metadata or sub-resource events.
 
 `credentialSubject.id` in the VC must equal `{assetId}:v{N}` — any mismatch returns 400. VC 1.1 payloads and payloads using the CAT-internal namespace are also rejected with 400. A duplicate `credentialId` (VC `id` field) returns 409.
 
-When a graph store is active, the corresponding PROV-O triple is written under the versioned asset IRI `{assetId}:v{N}` as a side-effect.
+`credentialSubject` MAY declare any combination of the recognised PROV-O predicates: `prov:wasGeneratedBy`, `prov:wasDerivedFrom`, `prov:wasAttributedTo`, `prov:wasRevisionOf`, `prov:generated`, `prov:used`, `prov:wasAssociatedWith`, `prov:actedOnBehalfOf`. Both compact (`prov:X`) and expanded (`http://www.w3.org/ns/prov#X`) forms are accepted. When a graph store is active, **every** recognised predicate is projected as its own triple under the versioned asset IRI `{assetId}:v{N}`; the predicate that appears first on `credentialSubject` is also written to the relational store as the row's primary type discriminator for filtering.
 
 [mermaid, width=2000]
 ....


### PR DESCRIPTION
## 🚀 Summary

Updates the arc42 architecture document for the Federated Catalogue to reflect the PROV-O alignment work in the companion service PR. Chapter 05 (building block view) is rewritten around the extended provenance flow, RDF-star reified projection, the cascade-by-asset-IRI endpoint, and the human-readable companion content-type policy. Chapter 06 picks up the activity-centric provenance runtime; chapter 09 adds the relevant ADR entries; chapter 12 (glossary) gains the PROV-O / SPARQL-Star / versioned-asset-IRI terms. Smaller alignment edits in chapters 01–04, 07–10, 13.

This change is part of the Enhancement of XFSC Federated Catalogue. Details can be found here (permalink):
https://github.com/eclipse-xfsc/docs/blob/f3c6e6b6fbcc87732a1dfe83f060fa58a9a97873/federated-catalogue/src/docs/CAT%20Enhancement/CAT_Enhancement_Specifications%20v1.0.pdf

## ✅ What's Changed

- [ ] Feature implemented / Bug fixed
- [x] Documentation updated
- [ ] Tests added or updated
- [x] Code formatted and linted (AsciiDoc only)

## 🧪 How to Test

1. Render the arc42 doc locally (\`asciidoctor\` against \`federated-catalogue/src/docs/architecture/catalogue-architecture.adoc\`) and confirm chapters 05, 06, 09, 12 render without missing-anchor warnings.
2. Cross-check the chapter 05 building-block diagram and the runtime sequence in 06 against the companion service PR's OpenAPI prose to confirm field names and endpoint paths match.
3. Verify chapter 09 ADR entries reference only other ADRs or pinned external specs (no internal planning artefacts).

## 🔍 Related Issues

Closes #<issue-number>
Related to #<other-issue>

## 📸 Screenshots (if applicable)

<!-- Not a UI change -->

## 📋 Checklist

- [ ] I've tested my code locally
- [ ] I've added tests if needed
- [ ] I've updated documentation if necessary
- [ ] My changes follow the project's coding style